### PR TITLE
feat: convert airport DNS policy into each client target

### DIFF
--- a/Tower/AppModel.swift
+++ b/Tower/AppModel.swift
@@ -364,6 +364,7 @@ final class AppModel {
         var updated = source
         updated.lastUpdatedAt = .now
         updated.usage = result.usage
+        updated.dnsConfiguration = result.dnsConfiguration
         subscriptions.append(updated)
         nodes.append(contentsOf: result.nodes)
         persist()
@@ -400,6 +401,7 @@ final class AppModel {
             subscriptions[index].lastUpdatedAt = .now
             subscriptions[index].lastError = nil
             subscriptions[index].usage = result.usage
+            subscriptions[index].dnsConfiguration = result.dnsConfiguration
             persist()
             showToast(importSummary("已更新", result: result), symbol: "arrow.triangle.2.circlepath.circle.fill")
         } catch {
@@ -460,6 +462,13 @@ final class AppModel {
     func configuration(target: ClientTarget? = nil) -> GeneratedConfiguration {
         let resolvedTarget = target ?? selectedTarget
         let currentNodes = enabledNodes
+        // Enabled subscriptions merge in list order: the first non-empty value
+        // wins per global field, the first occurrence wins per matcher. A
+        // disabled subscription contributes nothing and drops out of the cache
+        // key below, so toggling it invalidates the cached configuration.
+        let dnsConfiguration = SubscriptionDNSConfiguration.merged(
+            subscriptions.filter(\.isEnabled).compactMap(\.dnsConfiguration)
+        )
         let currentNodeIDs = Set(currentNodes.map(\.id))
         let currentCountryCodes = nodeIPCountryCodes.filter { currentNodeIDs.contains($0.key) }
         let countryCodesHash = currentCountryCodes
@@ -476,7 +485,10 @@ final class AppModel {
             countryCodesHash: countryCodesHash,
             // Without this, toggling a protocol would keep serving the cached
             // configuration for that client.
-            excludedHash: excluded.map(\.rawValue).sorted().joined(separator: "|").hashValue
+            excludedHash: excluded.map(\.rawValue).sorted().joined(separator: "|").hashValue,
+            // DNS metadata merges from the enabled subscriptions, so disabling
+            // one changes this hash and invalidates the cached configuration.
+            dnsHash: dnsConfiguration?.hashValue ?? 0
         )
         if let cached = generationCache[key] { return cached }
 
@@ -488,7 +500,8 @@ final class AppModel {
                 scheme: scheme,
                 target: resolvedTarget,
                 schemes: schemeRepository,
-                excludedKinds: excluded
+                excludedKinds: excluded,
+                dnsConfiguration: dnsConfiguration
             )
         } else {
             generated = generator.generate(
@@ -496,7 +509,8 @@ final class AppModel {
                 preset: selectedPreset,
                 target: resolvedTarget,
                 countryCodes: currentCountryCodes,
-                excludedKinds: excluded
+                excludedKinds: excluded,
+                dnsConfiguration: dnsConfiguration
             )
         }
         generationCache[key] = generated
@@ -591,19 +605,24 @@ struct GenerationCacheKey: Hashable {
     let nodesHash: Int
     let countryCodesHash: Int
     let excludedHash: Int
+    /// Merged DNS metadata. Toggling a subscription changes it, which drops
+    /// the cached configuration for that key.
+    let dnsHash: Int
 
     init(
         target: ClientTarget,
         presetID: String,
         nodesHash: Int,
         countryCodesHash: Int,
-        excludedHash: Int = 0
+        excludedHash: Int = 0,
+        dnsHash: Int = 0
     ) {
         self.target = target
         self.presetID = presetID
         self.nodesHash = nodesHash
         self.countryCodesHash = countryCodesHash
         self.excludedHash = excludedHash
+        self.dnsHash = dnsHash
     }
 
     fileprivate var signature: GenerationCacheSignature {

--- a/Tower/Features/Export/ExportView.swift
+++ b/Tower/Features/Export/ExportView.swift
@@ -283,6 +283,30 @@ private struct ConversionSummary: View {
                 .font(.caption)
                 .foregroundStyle(.orange)
             }
+            if !configuration.conversionWarnings.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label(
+                        "\(configuration.conversionWarnings.count) 条 DNS 配置未能转换",
+                        systemImage: "exclamationmark.triangle.fill"
+                    )
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.orange)
+                    ForEach(configuration.conversionWarnings.prefix(3), id: \.self) { warning in
+                        Text(warning)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    if configuration.conversionWarnings.count > 3 {
+                        Text("等 \(configuration.conversionWarnings.count) 条……")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                    Text("未转换的 DNS 条目不会写入配置，也不影响预览、复制或导入。")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
         .padding(20)
         .towerCard()

--- a/Tower/Models/DomainModels.swift
+++ b/Tower/Models/DomainModels.swift
@@ -35,6 +35,10 @@ struct SubscriptionSource: Identifiable, Codable, Hashable {
     var lastError: String?
     /// Plan usage reported by the airport, when it reports any.
     var usage: SubscriptionUsage?
+    /// The Clash `dns:` block the airport supplied. Tower carries this metadata
+    /// into generated configurations instead of silently discarding it; the
+    /// node list from the subscription remains authoritative.
+    var dnsConfiguration: SubscriptionDNSConfiguration?
 
     init(
         id: UUID = UUID(),
@@ -44,7 +48,8 @@ struct SubscriptionSource: Identifiable, Codable, Hashable {
         createdAt: Date = .now,
         lastUpdatedAt: Date? = nil,
         lastError: String? = nil,
-        usage: SubscriptionUsage? = nil
+        usage: SubscriptionUsage? = nil,
+        dnsConfiguration: SubscriptionDNSConfiguration? = nil
     ) {
         self.id = id
         self.name = name
@@ -54,10 +59,78 @@ struct SubscriptionSource: Identifiable, Codable, Hashable {
         self.lastUpdatedAt = lastUpdatedAt
         self.lastError = lastError
         self.usage = usage
+        self.dnsConfiguration = dnsConfiguration
     }
 
     var safeHost: String {
         URL(string: urlString)?.host ?? "私密订阅"
+    }
+}
+
+struct NameserverPolicyEntry: Codable, Hashable, Sendable {
+    let matcher: String
+    let nameservers: [String]
+}
+
+/// The `dns:` block a Clash/Mihomo subscription carries, read verbatim and
+/// re-emitted per target. The node list stays authoritative; this is metadata
+/// Tower would otherwise silently discard. Fields absent from the airport's
+/// block stay empty and fall back to each target's built-in defaults.
+struct SubscriptionDNSConfiguration: Codable, Hashable, Sendable {
+    /// `enable`
+    var enable: Bool? = nil
+    /// `default-nameserver` — plain resolvers used to bootstrap the DoH/DoT
+    /// server hostnames in `nameservers`.
+    var defaultNameservers: [String] = []
+    /// `nameserver` — the resolvers ordinary domains are sent to.
+    var nameservers: [String] = []
+    /// `fallback` — resolvers used when the primary group fails.
+    var fallbacks: [String] = []
+    /// `nameserver-policy` — matcher to resolver routing.
+    var nameserverPolicy: [NameserverPolicyEntry] = []
+    /// `proxy-server-nameserver` — resolvers for proxy node hostnames.
+    var proxyServerNameservers: [String] = []
+    /// `proxy-server-nameserver-policy` — per-matcher proxy node resolution.
+    var proxyServerNameserverPolicy: [NameserverPolicyEntry] = []
+
+    var isEmpty: Bool {
+        defaultNameservers.isEmpty && nameservers.isEmpty && fallbacks.isEmpty
+            && nameserverPolicy.isEmpty && proxyServerNameservers.isEmpty
+            && proxyServerNameserverPolicy.isEmpty
+    }
+
+    /// Multi-subscription merge in list order. Every global field keeps its
+    /// first non-empty value (upstream servers from different airports are
+    /// never mixed), and each matcher keeps the first policy that mentions it.
+    /// Disabled subscriptions never reach this point.
+    static func merged(_ configs: [SubscriptionDNSConfiguration]) -> SubscriptionDNSConfiguration? {
+        var result = SubscriptionDNSConfiguration()
+        for config in configs {
+            if result.enable == nil { result.enable = config.enable }
+            if result.defaultNameservers.isEmpty { result.defaultNameservers = config.defaultNameservers }
+            if result.nameservers.isEmpty { result.nameservers = config.nameservers }
+            if result.fallbacks.isEmpty { result.fallbacks = config.fallbacks }
+            if result.proxyServerNameservers.isEmpty { result.proxyServerNameservers = config.proxyServerNameservers }
+            result.nameserverPolicy = Self.mergePolicies(result.nameserverPolicy, config.nameserverPolicy)
+            result.proxyServerNameserverPolicy = Self.mergePolicies(
+                result.proxyServerNameserverPolicy,
+                config.proxyServerNameserverPolicy
+            )
+        }
+        return result.isEmpty ? nil : result
+    }
+
+    private static func mergePolicies(
+        _ current: [NameserverPolicyEntry],
+        _ incoming: [NameserverPolicyEntry]
+    ) -> [NameserverPolicyEntry] {
+        var result = current
+        var seen = Set(current.map(\.matcher))
+        for entry in incoming where !seen.contains(entry.matcher) {
+            seen.insert(entry.matcher)
+            result.append(entry)
+        }
+        return result
     }
 }
 
@@ -832,6 +905,9 @@ struct ImportResult: Sendable {
     let nodes: [ProxyNode]
     let rejectedLineCount: Int
     var usage: SubscriptionUsage?
+    /// DNS metadata parsed from the subscription body. `nil` when the airport
+    /// shipped none, which keeps every generator on its built-in defaults.
+    var dnsConfiguration: SubscriptionDNSConfiguration?
 }
 
 struct GeneratedConfiguration {
@@ -840,6 +916,10 @@ struct GeneratedConfiguration {
     let supportedNodeCount: Int
     let skippedNodeCount: Int
     let ruleCount: Int
+    /// DNS entries that could not be carried into this target's format,
+    /// deduplicated and shown in the export summary. Never blocks preview,
+    /// copy or import.
+    var conversionWarnings: [String] = []
 
     var fileName: String {
         "塔台-\(target.name)-\(Self.timestamp).\(target.fileExtension)"

--- a/Tower/Services/ConfigurationGenerator.swift
+++ b/Tower/Services/ConfigurationGenerator.swift
@@ -43,29 +43,34 @@ struct ConfigurationGenerator {
         preset: RulePreset,
         target: ClientTarget,
         countryCodes: [UUID: String] = [:],
-        excludedKinds: Set<ProxyKind> = []
+        excludedKinds: Set<ProxyKind> = [],
+        dnsConfiguration: SubscriptionDNSConfiguration? = nil
     ) -> GeneratedConfiguration {
+        // An empty block means the airport shipped no usable field, so it falls
+        // back to the same built-in defaults as no block at all.
+        let dns = dnsConfiguration?.isEmpty == true ? nil : dnsConfiguration
         let supported = uniquedNames(
             nodes.filter { writes($0, to: target, excluding: excludedKinds) },
             reservedNames: reservedProxyNames(for: preset)
         )
         let regionGroups = makeRegionGroups(nodes: supported, countryCodes: countryCodes)
+        var warnings: [String] = []
         let content: String
         switch target {
         case .clash:
-            content = clash(nodes: supported, preset: preset, regionGroups: regionGroups)
+            content = clash(nodes: supported, preset: preset, regionGroups: regionGroups, dns: dns, warnings: &warnings)
         case .surge:
-            content = surgeLike(nodes: supported, preset: preset, regionGroups: regionGroups, shadowrocket: false)
+            content = surgeLike(nodes: supported, preset: preset, regionGroups: regionGroups, shadowrocket: false, dns: dns, warnings: &warnings)
         case .shadowrocket:
-            content = surgeLike(nodes: supported, preset: preset, regionGroups: regionGroups, shadowrocket: true)
+            content = surgeLike(nodes: supported, preset: preset, regionGroups: regionGroups, shadowrocket: true, dns: dns, warnings: &warnings)
         case .loon:
-            content = loon(nodes: supported, preset: preset, regionGroups: regionGroups)
+            content = loon(nodes: supported, preset: preset, regionGroups: regionGroups, dns: dns, warnings: &warnings)
         case .quanx:
-            content = quanX(nodes: supported, preset: preset, regionGroups: regionGroups)
+            content = quanX(nodes: supported, preset: preset, regionGroups: regionGroups, dns: dns, warnings: &warnings)
         case .hiddify:
-            content = singBox(nodes: supported, preset: preset, regionGroups: regionGroups)
+            content = singBox(nodes: supported, preset: preset, regionGroups: regionGroups, dns: dns, warnings: &warnings)
         case .egern:
-            content = egern(nodes: supported, preset: preset, regionGroups: regionGroups)
+            content = egern(nodes: supported, preset: preset, regionGroups: regionGroups, dns: dns, warnings: &warnings)
         }
 
         return GeneratedConfiguration(
@@ -73,7 +78,8 @@ struct ConfigurationGenerator {
             content: content,
             supportedNodeCount: supported.count,
             skippedNodeCount: nodes.count - supported.count,
-            ruleCount: rules.count(for: preset)
+            ruleCount: rules.count(for: preset),
+            conversionWarnings: warnings.removingDuplicates()
         )
     }
 
@@ -86,27 +92,32 @@ struct ConfigurationGenerator {
         scheme: RuleScheme,
         target: ClientTarget,
         schemes: RuleSchemeRepository = RuleSchemeRepository(),
-        excludedKinds: Set<ProxyKind> = []
+        excludedKinds: Set<ProxyKind> = [],
+        dnsConfiguration: SubscriptionDNSConfiguration? = nil
     ) -> GeneratedConfiguration {
+        // An empty block means the airport shipped no usable field, so it falls
+        // back to the same built-in defaults as no block at all.
+        let dns = dnsConfiguration?.isEmpty == true ? nil : dnsConfiguration
         let supported = uniquedNames(
             nodes.filter { writes($0, to: target, excluding: excludedKinds) },
             reservedNames: Set(scheme.groups.map(\.name) + ["DIRECT", "REJECT", "direct", "reject"])
         )
         let resolved = resolveGroups(scheme: scheme, nodes: supported, target: target)
+        var warnings: [String] = []
         let content: String
         switch target {
         case .clash:
-            content = clashScheme(scheme, groups: resolved, nodes: supported, schemes: schemes)
+            content = clashScheme(scheme, groups: resolved, nodes: supported, schemes: schemes, dns: dns, warnings: &warnings)
         case .surge, .shadowrocket:
-            content = surgeLikeScheme(scheme, groups: resolved, nodes: supported, target: target, schemes: schemes)
+            content = surgeLikeScheme(scheme, groups: resolved, nodes: supported, target: target, schemes: schemes, dns: dns, warnings: &warnings)
         case .loon:
-            content = loonScheme(scheme, groups: resolved, nodes: supported, schemes: schemes)
+            content = loonScheme(scheme, groups: resolved, nodes: supported, schemes: schemes, dns: dns, warnings: &warnings)
         case .quanx:
-            content = quanXScheme(scheme, groups: resolved, nodes: supported, schemes: schemes)
+            content = quanXScheme(scheme, groups: resolved, nodes: supported, schemes: schemes, dns: dns, warnings: &warnings)
         case .hiddify:
-            content = singBoxScheme(scheme, groups: resolved, nodes: supported, schemes: schemes)
+            content = singBoxScheme(scheme, groups: resolved, nodes: supported, schemes: schemes, dns: dns, warnings: &warnings)
         case .egern:
-            content = egernScheme(scheme, groups: resolved, nodes: supported, schemes: schemes)
+            content = egernScheme(scheme, groups: resolved, nodes: supported, schemes: schemes, dns: dns, warnings: &warnings)
         }
 
         return GeneratedConfiguration(
@@ -114,7 +125,8 @@ struct ConfigurationGenerator {
             content: content,
             supportedNodeCount: supported.count,
             skippedNodeCount: nodes.count - supported.count,
-            ruleCount: ruleCount(for: scheme, schemes: schemes)
+            ruleCount: ruleCount(for: scheme, schemes: schemes),
+            conversionWarnings: warnings.removingDuplicates()
         )
     }
 
@@ -281,7 +293,9 @@ struct ConfigurationGenerator {
         _ scheme: RuleScheme,
         groups: [ResolvedSchemeGroup],
         nodes: [ProxyNode],
-        schemes: RuleSchemeRepository
+        schemes: RuleSchemeRepository,
+        dns: SubscriptionDNSConfiguration?,
+        warnings: inout [String]
     ) -> String {
         var output = schemeHeader(scheme, target: .clash)
         output += """
@@ -291,6 +305,11 @@ struct ConfigurationGenerator {
         log-level: warning
         ipv6: true
 
+        """
+        let (dnsText, dnsWarnings) = clashDNS(dns)
+        warnings += dnsWarnings
+        output += dnsText
+        output += """
         proxies:
         """
         output += "\n"
@@ -321,20 +340,15 @@ struct ConfigurationGenerator {
         groups: [ResolvedSchemeGroup],
         nodes: [ProxyNode],
         target: ClientTarget,
-        schemes: RuleSchemeRepository
+        schemes: RuleSchemeRepository,
+        dns: SubscriptionDNSConfiguration?,
+        warnings: inout [String]
     ) -> String {
+        let (generalDNS, hostDNS) = surgeFamilyDNS(dns, shadowrocket: target == .shadowrocket, warnings: &warnings)
         var output = schemeHeader(scheme, target: target)
-        output += """
-        [General]
-        loglevel = notify
-        ipv6 = true
-        dns-server = system, 223.5.5.5, 1.1.1.1
-        skip-proxy = 127.0.0.1, localhost, *.local
-        test-timeout = 5
-
-        [Proxy]
-        """
-        output += "\n"
+        output += "[General]\nloglevel = notify\nipv6 = true\n"
+        output += generalDNS
+        output += "skip-proxy = 127.0.0.1, localhost, *.local\ntest-timeout = 5\n\n[Proxy]\n"
         for node in nodes {
             output += surgeNode(node, shadowrocket: target == .shadowrocket) + "\n"
         }
@@ -351,6 +365,7 @@ struct ConfigurationGenerator {
         }
         output += "\n[Rule]\n"
         output += schemeRules(scheme, target: target, schemes: schemes)
+        output += hostDNS
         return output
     }
 
@@ -358,17 +373,16 @@ struct ConfigurationGenerator {
         _ scheme: RuleScheme,
         groups: [ResolvedSchemeGroup],
         nodes: [ProxyNode],
-        schemes: RuleSchemeRepository
+        schemes: RuleSchemeRepository,
+        dns: SubscriptionDNSConfiguration?,
+        warnings: inout [String]
     ) -> String {
+        let generalDNS = loonGeneralDNS(dns, warnings: &warnings)
+        let hostDNS = hostSectionDNS(dns?.nameserverPolicy ?? [], targetName: "Loon", allowEncrypted: true, warnings: &warnings)
         var output = schemeHeader(scheme, target: .loon)
-        output += """
-        [General]
-        ipv6 = true
-        dns-server = system, 223.5.5.5, 1.1.1.1
-
-        [Proxy]
-        """
-        output += "\n"
+        output += "[General]\nipv6 = true\n"
+        output += generalDNS
+        output += "\n[Proxy]\n"
         for node in nodes { output += loonNode(node) + "\n" }
         output += "\n[Proxy Group]\n"
         for group in groups {
@@ -383,6 +397,7 @@ struct ConfigurationGenerator {
         }
         output += "\n[Rule]\n"
         output += schemeRules(scheme, target: .loon, schemes: schemes)
+        output += hostDNS
         return output
     }
 
@@ -390,7 +405,9 @@ struct ConfigurationGenerator {
         _ scheme: RuleScheme,
         groups: [ResolvedSchemeGroup],
         nodes: [ProxyNode],
-        schemes: RuleSchemeRepository
+        schemes: RuleSchemeRepository,
+        dns: SubscriptionDNSConfiguration?,
+        warnings: inout [String]
     ) -> String {
         var output = schemeHeader(scheme, target: .quanx)
         output += """
@@ -398,13 +415,9 @@ struct ConfigurationGenerator {
         server_check_url = http://www.gstatic.com/generate_204
         server_check_timeout = 5000
 
-        [dns]
-        no-system
-        server = 223.5.5.5
-        server = 1.1.1.1
-
-        [server_local]
         """
+        output += quanXDNS(dns, warnings: &warnings)
+        output += "[server_local]"
         output += "\n"
         for node in nodes { output += quanXNode(node) + "\n" }
         output += "\n[policy]\n"
@@ -433,7 +446,9 @@ struct ConfigurationGenerator {
     private func clash(
         nodes: [ProxyNode],
         preset: RulePreset,
-        regionGroups: [RegionStrategyGroup]
+        regionGroups: [RegionStrategyGroup],
+        dns: SubscriptionDNSConfiguration?,
+        warnings: inout [String]
     ) -> String {
         let nodeNames = nodes.map { NodeRegionResolver.displayName(for: $0) }
         let regionGroupNames = regionGroups.map(\.name)
@@ -445,6 +460,11 @@ struct ConfigurationGenerator {
         log-level: warning
         ipv6: true
 
+        """
+        let (dnsText, dnsWarnings) = clashDNS(dns)
+        warnings += dnsWarnings
+        output += dnsText
+        output += """
         proxies:
         """
         output += "\n"
@@ -526,6 +546,45 @@ struct ConfigurationGenerator {
         }
         output += "  - MATCH,\(clashPolicyName(preset.finalPolicy))\n"
         return output
+    }
+
+    /// The `dns:` block for Stash/Clash, which speaks the same vocabulary the
+    /// airport used. Built-in defaults fill only the fields the airport left
+    /// blank; Mihomo-only proxy fields are dropped with a warning.
+    private func clashDNS(_ dns: SubscriptionDNSConfiguration?) -> (text: String, warnings: [String]) {
+        var warnings: [String] = []
+        var lines: [String] = ["dns:", "  enable: \(dns?.enable ?? true)"]
+
+        if let defaultNameservers = dns?.defaultNameservers, !defaultNameservers.isEmpty {
+            lines.append("  default-nameserver:")
+            for resolver in defaultNameservers { lines.append("    - \(yaml(resolver))") }
+        }
+
+        let nameservers = dns?.nameservers ?? ["https://223.5.5.5/dns-query", "https://1.1.1.1/dns-query"]
+        lines.append("  nameserver:")
+        for resolver in nameservers { lines.append("    - \(yaml(resolver))") }
+
+        if let fallbacks = dns?.fallbacks, !fallbacks.isEmpty {
+            lines.append("  fallback:")
+            for resolver in fallbacks { lines.append("    - \(yaml(resolver))") }
+        }
+
+        if let policy = dns?.nameserverPolicy, !policy.isEmpty {
+            lines.append("  nameserver-policy:")
+            var seen = Set<String>()
+            for entry in policy where seen.insert(entry.matcher).inserted && !entry.nameservers.isEmpty {
+                lines.append("    \(yaml(entry.matcher)):")
+                for resolver in entry.nameservers { lines.append("      - \(yaml(resolver))") }
+            }
+        }
+
+        if let proxy = dns?.proxyServerNameservers, !proxy.isEmpty {
+            warnings.append("Stash 不输出 Mihomo 专属的 proxy-server-nameserver（\(proxy.count) 个解析器），已跳过")
+        }
+        if let proxyPolicy = dns?.proxyServerNameserverPolicy, !proxyPolicy.isEmpty {
+            warnings.append("Stash 不输出 Mihomo 专属的 proxy-server-nameserver-policy（\(proxyPolicy.count) 条），已跳过")
+        }
+        return (lines.joined(separator: "\n") + "\n\n", warnings)
     }
 
     private func clashNode(_ node: ProxyNode) -> String {
@@ -674,22 +733,18 @@ struct ConfigurationGenerator {
         nodes: [ProxyNode],
         preset: RulePreset,
         regionGroups: [RegionStrategyGroup],
-        shadowrocket: Bool
+        shadowrocket: Bool,
+        dns: SubscriptionDNSConfiguration?,
+        warnings: inout [String]
     ) -> String {
         let target: ClientTarget = shadowrocket ? .shadowrocket : .surge
         let names = nodes.map { NodeRegionResolver.displayName(for: $0) }
         let regionGroupNames = regionGroups.map(\.name)
+        let (generalDNS, hostDNS) = surgeFamilyDNS(dns, shadowrocket: shadowrocket, warnings: &warnings)
         var output = header(target: target)
-        output += """
-        [General]
-        loglevel = notify
-        ipv6 = true
-        dns-server = system, 223.5.5.5, 1.1.1.1
-        skip-proxy = 127.0.0.1, localhost, *.local
-        test-timeout = 5
-
-        [Proxy]
-        """
+        output += "[General]\nloglevel = notify\nipv6 = true\n"
+        output += generalDNS
+        output += "skip-proxy = 127.0.0.1, localhost, *.local\ntest-timeout = 5\n\n[Proxy]"
         output += "\n"
         for node in nodes {
             output += surgeNode(node, shadowrocket: shadowrocket) + "\n"
@@ -768,6 +823,7 @@ struct ConfigurationGenerator {
         }
         if preset.includeGeoIPCN { output += "GEOIP,CN,DIRECT,no-resolve\n" }
         output += "FINAL,\(surgePolicyName(preset.finalPolicy))\n"
+        output += hostDNS
         return output
     }
 
@@ -914,18 +970,18 @@ struct ConfigurationGenerator {
     private func loon(
         nodes: [ProxyNode],
         preset: RulePreset,
-        regionGroups: [RegionStrategyGroup]
+        regionGroups: [RegionStrategyGroup],
+        dns: SubscriptionDNSConfiguration?,
+        warnings: inout [String]
     ) -> String {
         let names = nodes.map { NodeRegionResolver.displayName(for: $0) }
         let regionGroupNames = regionGroups.map(\.name)
+        let generalDNS = loonGeneralDNS(dns, warnings: &warnings)
+        let hostDNS = hostSectionDNS(dns?.nameserverPolicy ?? [], targetName: "Loon", allowEncrypted: true, warnings: &warnings)
         var output = header(target: .loon)
-        output += """
-        [General]
-        ipv6 = true
-        dns-server = system, 223.5.5.5, 1.1.1.1
-
-        [Proxy]
-        """
+        output += "[General]\nipv6 = true\n"
+        output += generalDNS
+        output += "\n[Proxy]"
         output += "\n"
         for node in nodes { output += loonNode(node) + "\n" }
         output += "\n[Proxy Group]\n"
@@ -976,6 +1032,7 @@ struct ConfigurationGenerator {
         }
         if preset.includeGeoIPCN { output += "GEOIP,CN,DIRECT\n" }
         output += "FINAL,\(surgePolicyName(preset.finalPolicy))\n"
+        output += hostDNS
         return output
     }
 
@@ -1081,7 +1138,9 @@ struct ConfigurationGenerator {
     private func quanX(
         nodes: [ProxyNode],
         preset: RulePreset,
-        regionGroups: [RegionStrategyGroup]
+        regionGroups: [RegionStrategyGroup],
+        dns: SubscriptionDNSConfiguration?,
+        warnings: inout [String]
     ) -> String {
         let names = nodes.map { NodeRegionResolver.displayName(for: $0) }
         let regionGroupNames = regionGroups.map(\.name)
@@ -1091,13 +1150,9 @@ struct ConfigurationGenerator {
         server_check_url = http://www.gstatic.com/generate_204
         server_check_timeout = 5000
 
-        [dns]
-        no-system
-        server = 223.5.5.5
-        server = 1.1.1.1
-
-        [server_local]
         """
+        output += quanXDNS(dns, warnings: &warnings)
+        output += "[server_local]"
         output += "\n"
         for node in nodes { output += quanXNode(node) + "\n" }
         output += "\n[policy]\n"
@@ -1554,6 +1609,580 @@ struct ConfigurationGenerator {
             .replacingOccurrences(of: "\r", with: " ")
             .replacingOccurrences(of: "\n", with: " ")
     }
+
+    // MARK: - DNS conversion
+
+    /// [General] DNS lines for Surge and Shadowrocket, plus the `[Host]`
+    /// section carrying the nameserver policy. Shadowrocket spells some keys
+    /// differently and can express a global proxy resolver (`proxy-dns-server`)
+    /// where Surge has nothing at all.
+    private func surgeFamilyDNS(
+        _ dns: SubscriptionDNSConfiguration?,
+        shadowrocket: Bool,
+        warnings: inout [String]
+    ) -> (general: String, host: String) {
+        let targetName = shadowrocket ? "Shadowrocket" : "Surge"
+        guard let dns else {
+            return ("dns-server = system, 223.5.5.5, 1.1.1.1\n", "")
+        }
+
+        var plain: [String] = ["system"]
+        var encrypted: [String] = []
+        var fallbackPlain: [String] = []
+
+        // default-nameserver is the plain resolver that bootstraps the DoH
+        // hostnames — the same role dns-server plays in Surge, so it joins it.
+        // Every value is untrusted airport text, so it goes through confValue
+        // (folds newlines, encodes commas) exactly like a node parameter.
+        for resolver in dns.defaultNameservers {
+            guard let kind = DNSProtocolKind.classify(resolver), kind == .plain else {
+                warnings.append("\(targetName) 的 dns-server 不接受非普通 DNS `\(resolver)`，已跳过")
+                continue
+            }
+            plain.append(confValue(plainResolverAddress(resolver)))
+        }
+
+        let nameservers = dns.nameservers.isEmpty
+            ? ["https://223.5.5.5/dns-query", "https://1.1.1.1/dns-query"]
+            : dns.nameservers
+        for resolver in nameservers {
+            guard let kind = DNSProtocolKind.classify(resolver) else {
+                warnings.append("\(targetName) 无法识别的 DNS 解析器 `\(resolver)`，已跳过")
+                continue
+            }
+            switch kind {
+            case .plain:
+                plain.append(confValue(plainResolverAddress(resolver)))
+            case .doh, .doh3, .doq:
+                if shadowrocket {
+                    warnings.append("Shadowrocket 的 dns-server 不表达 \(kind.name) DNS，`\(resolver)` 已跳过")
+                } else {
+                    encrypted.append(confValue(resolver))
+                }
+            case .dot:
+                warnings.append("\(targetName) 不表达 DoT 解析器 `\(resolver)`，已跳过")
+            }
+        }
+
+        // Surge's dns-server list already fails over, so its fallbacks join the
+        // list; Shadowrocket keeps a dedicated key.
+        for resolver in dns.fallbacks {
+            guard let kind = DNSProtocolKind.classify(resolver) else { continue }
+            switch kind {
+            case .plain:
+                if shadowrocket {
+                    fallbackPlain.append(confValue(plainResolverAddress(resolver)))
+                } else {
+                    plain.append(confValue(plainResolverAddress(resolver)))
+                }
+            case .doh, .doh3, .doq:
+                if shadowrocket {
+                    warnings.append("Shadowrocket 的 fallback-dns-server 不表达 \(kind.name) DNS，`\(resolver)` 已跳过")
+                } else {
+                    encrypted.append(confValue(resolver))
+                }
+            case .dot:
+                warnings.append("\(targetName) 不表达 DoT fallback `\(resolver)`，已跳过")
+            }
+        }
+
+        var general = "dns-server = \(plain.joined(separator: ", "))\n"
+        if !encrypted.isEmpty {
+            general += "encrypted-dns-server = \(encrypted.joined(separator: ", "))\n"
+        }
+        if shadowrocket, !fallbackPlain.isEmpty {
+            general += "fallback-dns-server = \(fallbackPlain.joined(separator: ", "))\n"
+        }
+
+        if !dns.proxyServerNameservers.isEmpty { let proxy = dns.proxyServerNameservers
+            if shadowrocket {
+                var valid: [String] = []
+                for resolver in proxy {
+                    guard let kind = DNSProtocolKind.classify(resolver), kind == .plain else {
+                        warnings.append("Shadowrocket 的 proxy-dns-server 不表达非普通 DNS `\(resolver)`，已跳过")
+                        continue
+                    }
+                    valid.append(confValue(plainResolverAddress(resolver)))
+                }
+                if !valid.isEmpty {
+                    general += "proxy-dns-server = \(valid.joined(separator: ", "))\n"
+                }
+            } else {
+                warnings.append("Surge 没有对应 proxy-server-nameserver 的字段（\(proxy.count) 个解析器），已跳过")
+            }
+        }
+        if !dns.proxyServerNameserverPolicy.isEmpty { let proxyPolicy = dns.proxyServerNameserverPolicy
+            warnings.append("\(targetName) 没有按域区分代理节点 DNS 的字段（\(proxyPolicy.count) 条），已跳过")
+        }
+
+        let host = hostSectionDNS(dns.nameserverPolicy, targetName: targetName, allowEncrypted: true, warnings: &warnings)
+        return (general, host)
+    }
+
+    /// `[Host]` section mapping each policy matcher to a resolver, shared by
+    /// Surge, Shadowrocket and Loon. Only exact and `+.`/`*.` matchers convert;
+    /// geosite and unspellable resolver protocols are dropped with a warning.
+    private func hostSectionDNS(
+        _ policy: [NameserverPolicyEntry],
+        targetName: String,
+        allowEncrypted: Bool,
+        warnings: inout [String]
+    ) -> String {
+        var lines: [String] = ["[Host]"]
+        var any = false
+        var seen = Set<String>()
+        for entry in policy where seen.insert(entry.matcher).inserted && !entry.nameservers.isEmpty {
+            guard let matcher = DNSMatcherKind.classify(entry.matcher) else {
+                warnings.append("\(targetName) 无法表达 DNS matcher `\(entry.matcher)`，已跳过")
+                continue
+            }
+            if case .geosite = matcher {
+                warnings.append("\(targetName) 不支持 geosite DNS 匹配，`\(entry.matcher)` 已跳过")
+                continue
+            }
+            var resolvers: [String] = []
+            for resolver in entry.nameservers {
+                guard let kind = DNSProtocolKind.classify(resolver) else {
+                    warnings.append("\(targetName) 无法识别的 DNS 解析器 `\(resolver)`，已跳过")
+                    continue
+                }
+                switch kind {
+                case .plain:
+                    resolvers.append(plainResolverAddress(resolver))
+                case .doh where allowEncrypted:
+                    resolvers.append(resolver)
+                default:
+                    warnings.append("\(targetName) 的 [Host] 不表达 \(kind.name) 解析器 `\(resolver)`，已跳过")
+                }
+            }
+            guard !resolvers.isEmpty else {
+                warnings.append("\(targetName) 无法表达 `\(entry.matcher)` 的 DNS 解析器，已跳过")
+                continue
+            }
+            // Both sides are untrusted airport text: confName folds the matcher
+            // into a single line and neutralises brackets, confValue encodes
+            // any comma that would have split the resolver list.
+            lines.append("\(confName(hostPattern(matcher))) = server:\(resolvers.map(confValue).joined(separator: ","))")
+            any = true
+        }
+        return any ? lines.joined(separator: "\n") + "\n" : ""
+    }
+
+    private func hostPattern(_ matcher: DNSMatcherKind) -> String {
+        switch matcher {
+        case .exact(let domain): domain
+        // The [Host] sections of Surge, Shadowrocket and Loon only know the
+        // `*.domain` wildcard, which covers both Clash suffix forms.
+        case .suffix(let domain, _): "*.\(domain)"
+        case .geosite: ""
+        }
+    }
+
+    /// Loon's [General] splits resolvers by protocol. Its plain list already
+    /// fails over, so fallbacks join it rather than a dedicated key; DoT has no
+    /// home and is dropped with a warning.
+    private func loonGeneralDNS(_ dns: SubscriptionDNSConfiguration?, warnings: inout [String]) -> String {
+        guard let dns else { return "dns-server = system, 223.5.5.5, 1.1.1.1\n" }
+        var plain: [String] = ["system"]
+        var doh: [String] = []
+        var doq: [String] = []
+        var doh3: [String] = []
+        let nameservers = dns.nameservers.isEmpty
+            ? ["https://223.5.5.5/dns-query", "https://1.1.1.1/dns-query"]
+            : dns.nameservers
+        for resolver in dns.defaultNameservers + nameservers + dns.fallbacks {
+            guard let kind = DNSProtocolKind.classify(resolver) else {
+                warnings.append("Loon 无法识别的 DNS 解析器 `\(resolver)`，已跳过")
+                continue
+            }
+            switch kind {
+            case .plain: plain.append(confValue(plainResolverAddress(resolver)))
+            case .doh: doh.append(confValue(resolver))
+            case .doq: doq.append(confValue(resolver))
+            case .doh3: doh3.append(confValue(resolver))
+            case .dot:
+                warnings.append("Loon 不表达 DoT 解析器 `\(resolver)`，已跳过")
+            }
+        }
+        if !dns.proxyServerNameservers.isEmpty { let proxy = dns.proxyServerNameservers
+            warnings.append("Loon 没有对应 proxy-server-nameserver 的字段（\(proxy.count) 个解析器），已跳过")
+        }
+        if !dns.proxyServerNameserverPolicy.isEmpty { let proxyPolicy = dns.proxyServerNameserverPolicy
+            warnings.append("Loon 没有按域区分代理节点 DNS 的字段（\(proxyPolicy.count) 条），已跳过")
+        }
+        var lines = ["dns-server = \(plain.joined(separator: ", "))"]
+        if !doh.isEmpty { lines.append("doh-server = \(doh.joined(separator: ", "))") }
+        if !doq.isEmpty { lines.append("doq-server = \(doq.joined(separator: ", "))") }
+        if !doh3.isEmpty { lines.append("doh3-server = \(doh3.joined(separator: ", "))") }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// Quantumult X's `[dns]` section: plain resolvers on `server =`, DoH/DoQ
+    /// on their own keys, and matcher bindings written as `server = /domain/ns`.
+    /// DoT, DoH3 and the proxy fields have no home — all dropped with a warning.
+    private func quanXDNS(_ dns: SubscriptionDNSConfiguration?, warnings: inout [String]) -> String {
+        guard let dns else {
+            return "[dns]\nno-system\nserver = 223.5.5.5\nserver = 1.1.1.1\n\n"
+        }
+        var plain: [String] = []
+        var doh: [String] = []
+        var doq: [String] = []
+        var bindings: [String] = []
+
+        let nameservers = dns.nameservers.isEmpty
+            ? ["223.5.5.5", "1.1.1.1"]
+            : dns.nameservers
+        for resolver in dns.defaultNameservers + nameservers + dns.fallbacks {
+            guard let kind = DNSProtocolKind.classify(resolver) else {
+                warnings.append("Quantumult X 无法识别的 DNS 解析器 `\(resolver)`，已跳过")
+                continue
+            }
+            switch kind {
+            case .plain: plain.append(confValue(plainResolverAddress(resolver)))
+            case .doh: doh.append(confValue(resolver))
+            case .doq: doq.append(confValue(resolver))
+            case .dot, .doh3:
+                warnings.append("Quantumult X 不表达 \(kind.name) 解析器 `\(resolver)`，已跳过")
+            }
+        }
+
+        var seen = Set<String>()
+        for entry in dns.nameserverPolicy where seen.insert(entry.matcher).inserted && !entry.nameservers.isEmpty {
+            guard let matcher = DNSMatcherKind.classify(entry.matcher) else {
+                warnings.append("Quantumult X 无法表达 DNS matcher `\(entry.matcher)`，已跳过")
+                continue
+            }
+            if case .geosite = matcher {
+                warnings.append("Quantumult X 不支持 geosite DNS 匹配，`\(entry.matcher)` 已跳过")
+                continue
+            }
+            // QuanX spells the binding as `/pattern/resolver`, and the pattern
+            // already carries its trailing slash.
+            let pattern = confName(quanXHostPattern(matcher))
+            for resolver in entry.nameservers {
+                guard let kind = DNSProtocolKind.classify(resolver) else { continue }
+                switch kind {
+                case .plain: bindings.append("server = \(pattern)\(confValue(plainResolverAddress(resolver)))")
+                case .doh: bindings.append("doh-server = \(pattern)\(confValue(resolver))")
+                case .doq: bindings.append("doq-server = \(pattern)\(confValue(resolver))")
+                case .dot, .doh3:
+                    warnings.append("Quantumult X 不表达 \(kind.name) 解析器 `\(resolver)`，已跳过")
+                }
+            }
+        }
+
+        if !dns.proxyServerNameservers.isEmpty { let proxy = dns.proxyServerNameservers
+            warnings.append("Quantumult X 没有对应 proxy-server-nameserver 的字段（\(proxy.count) 个解析器），已跳过")
+        }
+        if !dns.proxyServerNameserverPolicy.isEmpty { let proxyPolicy = dns.proxyServerNameserverPolicy
+            warnings.append("Quantumult X 没有按域区分代理节点 DNS 的字段（\(proxyPolicy.count) 条），已跳过")
+        }
+
+        var lines = ["[dns]", "no-system"]
+        for resolver in plain { lines.append("server = \(resolver)") }
+        for resolver in doh { lines.append("doh-server = \(resolver)") }
+        for resolver in doq { lines.append("doq-server = \(resolver)") }
+        lines += bindings
+        return lines.joined(separator: "\n") + "\n\n"
+    }
+
+    private func quanXHostPattern(_ matcher: DNSMatcherKind) -> String {
+        switch matcher {
+        case .exact(let domain): "/\(domain)/"
+        // Quantumult X's `/*.domain/` binding covers the apex too, matching
+        // `+.` exactly and adding the apex for `*.`.
+        case .suffix(let domain, _): "/*.\(domain)/"
+        case .geosite: ""
+        }
+    }
+
+    /// Egern's `dns:` block. The airport's resolver groups map onto `upstreams`
+    /// (multi-resolver policies stay whole), policy matchers become `forward`
+    /// rules, and the global proxy resolver lands on `proxy_nameservers`.
+    private func egernDNS(_ dns: SubscriptionDNSConfiguration?, warnings: inout [String]) -> String {
+        guard let dns else { return "" }
+
+        var bootstrap: [String] = []
+        for resolver in dns.defaultNameservers {
+            guard let kind = DNSProtocolKind.classify(resolver), kind == .plain else {
+                warnings.append("Egern 的 bootstrap 只接受普通 DNS，`\(resolver)` 已跳过")
+                continue
+            }
+            bootstrap.append(plainResolverAddress(resolver))
+        }
+        if bootstrap.isEmpty { bootstrap = ["223.5.5.5"] }
+
+        let nameservers = dns.nameservers.isEmpty
+            ? ["https://223.5.5.5/dns-query", "https://1.1.1.1/dns-query"]
+            : dns.nameservers
+        var upstreams: [(name: String, resolvers: [String])] = [("main", nameservers + dns.fallbacks)]
+        var forwards: [String] = []
+        var seen = Set<String>()
+        for entry in dns.nameserverPolicy where seen.insert(entry.matcher).inserted && !entry.nameservers.isEmpty {
+            guard let matcher = DNSMatcherKind.classify(entry.matcher) else {
+                warnings.append("Egern 无法表达 DNS matcher `\(entry.matcher)`，已跳过")
+                continue
+            }
+            switch matcher {
+            case .geosite:
+                warnings.append("Egern 不支持 geosite DNS 匹配，`\(entry.matcher)` 已跳过")
+                continue
+            case .exact(let domain):
+                appendEgernForward(&forwards, &upstreams, type: "domain", domain: domain, entry: entry)
+            case .suffix(let domain, _):
+                appendEgernForward(&forwards, &upstreams, type: "domain_wildcard", domain: "*.\(domain)", entry: entry)
+            }
+        }
+        // Without a catch-all rule Egern would answer everything with the
+        // bootstrap resolvers, leaving the airport's main upstreams unused.
+        // The catch-all comes last, after the policy rules.
+        forwards.append("    - domain_regex:\n        match: \".*\"\n        value: \"main\"")
+
+        var lines = ["dns:", "  bootstrap:"]
+        for resolver in bootstrap { lines.append("    - \(yaml(resolver))") }
+        lines.append("  upstreams:")
+        for group in upstreams {
+            // Group names are always generated (`main` or a sanitised matcher),
+            // so the key needs no quoting; the resolvers inside are airport text
+            // and stay quoted.
+            lines.append("    \(group.name):")
+            for resolver in group.resolvers { lines.append("      - \(yaml(resolver))") }
+        }
+        lines.append("  forward:")
+        lines.append(contentsOf: forwards)
+        if !dns.proxyServerNameservers.isEmpty { let proxy = dns.proxyServerNameservers
+            lines.append("  proxy_nameservers:")
+            for resolver in proxy { lines.append("    - \(yaml(resolver))") }
+        }
+        if !dns.proxyServerNameserverPolicy.isEmpty { let proxyPolicy = dns.proxyServerNameserverPolicy
+            warnings.append("Egern 没有按域区分代理节点 DNS 的字段（\(proxyPolicy.count) 条），已跳过")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private func appendEgernForward(
+        _ forwards: inout [String],
+        _ upstreams: inout [(name: String, resolvers: [String])],
+        type: String,
+        domain: String,
+        entry: NameserverPolicyEntry
+    ) {
+        let value: String
+        if entry.nameservers.count == 1 {
+            value = entry.nameservers[0]
+        } else {
+            let name = egernUpstreamGroupName(entry.matcher)
+            upstreams.append((name, entry.nameservers))
+            value = name
+        }
+        forwards.append("    - \(type):\n        match: \(yaml(domain))\n        value: \(yaml(value))")
+    }
+
+    private func egernUpstreamGroupName(_ matcher: String) -> String {
+        let allowed = CharacterSet.alphanumerics
+        var result = "policy"
+        var pendingDash = false
+        for scalar in matcher.unicodeScalars {
+            if allowed.contains(scalar) {
+                if pendingDash { result.append("-"); pendingDash = false }
+                result.append(Character(scalar))
+            } else {
+                pendingDash = true
+            }
+        }
+        return result
+    }
+
+    /// The `dns` object for a sing-box document, plus the tags a proxy node's
+    /// `domain_resolver` should point at. With no airport DNS the built-in
+    /// remote/local pair is kept; otherwise every resolver becomes a server and
+    /// the matchers become rules.
+    private func singBoxDNS(
+        _ dns: SubscriptionDNSConfiguration?,
+        directTag: String,
+        selectTag: String,
+        warnings: inout [String]
+    ) -> SingBoxDNSPlan {
+        guard let dns else {
+            return SingBoxDNSPlan(
+                dns: [
+                    "servers": [
+                        ["tag": "remote", "address": "https://1.1.1.1/dns-query", "detour": selectTag],
+                        ["tag": "local", "address": "https://223.5.5.5/dns-query", "detour": directTag]
+                    ],
+                    "final": "local",
+                    "strategy": "prefer_ipv4"
+                ],
+                proxyTag: nil,
+                proxyMatchers: []
+            )
+        }
+
+        var servers: [[String: Any]] = []
+        var serverTags: [String: String] = [:]
+        func tag(for address: String) -> String {
+            if let existing = serverTags[address] { return existing }
+            let tag = "ns-\(serverTags.count)"
+            serverTags[address] = tag
+            servers.append(["tag": tag, "address": address, "detour": directTag])
+            return tag
+        }
+
+        let nameservers = dns.nameservers.isEmpty
+            ? ["https://223.5.5.5/dns-query", "https://1.1.1.1/dns-query"]
+            : dns.nameservers
+        for resolver in dns.defaultNameservers + nameservers + dns.fallbacks {
+            _ = tag(for: resolver)
+        }
+
+        var rules: [[String: Any]] = []
+        var seen = Set<String>()
+        for entry in dns.nameserverPolicy where seen.insert(entry.matcher).inserted && !entry.nameservers.isEmpty {
+            guard let matcher = DNSMatcherKind.classify(entry.matcher) else {
+                warnings.append("Hiddify 无法表达 DNS matcher `\(entry.matcher)`，已跳过")
+                continue
+            }
+            switch matcher {
+            case .geosite:
+                warnings.append("Hiddify 按方案不输出 geosite DNS 匹配，`\(entry.matcher)` 已跳过")
+                continue
+            case .exact(let domain):
+                rules.append(["domain": [domain], "server": tag(for: entry.nameservers[0])])
+            case .suffix(let domain, let includesApex):
+                // `+.example.com` includes the apex; `.example.com` with the
+                // leading dot is exactly that. `*.example.com` does not include
+                // it, so it is spelled as a wildcard.
+                if includesApex {
+                    rules.append(["domain_suffix": [".\(domain)"], "server": tag(for: entry.nameservers[0])])
+                } else {
+                    rules.append(["domain_wildcard": ["*.\(domain)"], "server": tag(for: entry.nameservers[0])])
+                }
+            }
+            if entry.nameservers.count > 1 {
+                warnings.append("Hiddify 的 dns 规则只支持单个解析器，`\(entry.matcher)` 的其余 \(entry.nameservers.count - 1) 个已忽略")
+            }
+        }
+
+        var proxyTag: String?
+        var proxyMatchers: [(kind: DNSMatcherKind, tag: String)] = []
+        if !dns.proxyServerNameservers.isEmpty { let proxy = dns.proxyServerNameservers
+            proxyTag = tag(for: proxy[0])
+            if proxy.count > 1 {
+                warnings.append("Hiddify 的 proxy-server-nameserver 只取第一个解析器，其余 \(proxy.count - 1) 个已忽略")
+            }
+        }
+        for entry in dns.proxyServerNameserverPolicy where !entry.nameservers.isEmpty {
+            guard let matcher = DNSMatcherKind.classify(entry.matcher) else {
+                warnings.append("Hiddify 无法表达代理 DNS matcher `\(entry.matcher)`，已跳过")
+                continue
+            }
+            if case .geosite = matcher {
+                warnings.append("Hiddify 不支持 geosite 代理 DNS 匹配，`\(entry.matcher)` 已跳过")
+                continue
+            }
+            proxyMatchers.append((kind: matcher, tag: tag(for: entry.nameservers[0])))
+            if entry.nameservers.count > 1 {
+                warnings.append("Hiddify 的代理 DNS 规则只取第一个解析器，`\(entry.matcher)` 的其余 \(entry.nameservers.count - 1) 个已忽略")
+            }
+        }
+
+        var dnsDict: [String: Any] = ["servers": servers, "final": tag(for: nameservers[0]), "strategy": "prefer_ipv4"]
+        if !rules.isEmpty { dnsDict["rules"] = rules }
+        return SingBoxDNSPlan(dns: dnsDict, proxyTag: proxyTag, proxyMatchers: proxyMatchers)
+    }
+}
+
+fileprivate enum DNSProtocolKind {
+    case plain, dot, doh, doh3, doq
+
+    static func classify(_ value: String) -> DNSProtocolKind? {
+        let lower = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if lower.hasPrefix("tls://") { return .dot }
+        if lower.hasPrefix("https://") { return .doh }
+        if lower.hasPrefix("h3://") { return .doh3 }
+        if lower.hasPrefix("quic://") { return .doq }
+        return .plain
+    }
+
+    var name: String {
+        switch self {
+        case .plain: "普通"
+        case .dot: "DoT"
+        case .doh: "DoH"
+        case .doh3: "DoH3"
+        case .doq: "DoQ"
+        }
+    }
+}
+
+fileprivate enum DNSMatcherKind {
+    case exact(String)
+    /// `+.example.com` (suffix including the apex) or `*.example.com`
+    /// (subdomains only) — the two Clash forms map differently on targets that
+    /// can tell them apart.
+    case suffix(domain: String, includesApex: Bool)
+    case geosite(String)
+
+    static func classify(_ matcher: String) -> DNSMatcherKind? {
+        let value = matcher.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.hasPrefix("geosite:") { return .geosite(String(value.dropFirst("geosite:".count))) }
+        if value.hasPrefix("+.") { return .suffix(domain: String(value.dropFirst(2)), includesApex: true) }
+        if value.hasPrefix("*.") { return .suffix(domain: String(value.dropFirst(2)), includesApex: false) }
+        // An exact domain carries no scheme, space or slash; anything else
+        // (rule-set:, browser, a matcher Tower cannot map) is skipped.
+        if value.contains(":") || value.contains(" ") || value.hasPrefix("/") { return nil }
+        return .exact(value)
+    }
+
+    /// Whether a proxy node's server hostname falls under this matcher.
+    func matches(host: String) -> Bool {
+        let candidate = host.lowercased()
+        switch self {
+        case .exact(let domain):
+            return candidate == domain.lowercased()
+        case .suffix(let domain, let includesApex):
+            let suffix = domain.lowercased()
+            if includesApex, candidate == suffix { return true }
+            return candidate.hasSuffix(".\(suffix)")
+        case .geosite:
+            return false
+        }
+    }
+}
+
+fileprivate struct SingBoxDNSPlan {
+    let dns: [String: Any]?
+    let proxyTag: String?
+    let proxyMatchers: [(kind: DNSMatcherKind, tag: String)]
+
+    /// The DNS server tag that answers this node's hostname, or nil when the
+    /// node is an IP literal or the airport configured no proxy resolver.
+    func domainResolverTag(for node: ProxyNode) -> String? {
+        guard isHostname(node.server) else { return nil }
+        for (kind, tag) in proxyMatchers where kind.matches(host: node.server) {
+            return tag
+        }
+        return proxyTag
+    }
+}
+
+fileprivate func isHostname(_ server: String) -> Bool {
+    let value = server.trimmingCharacters(in: .whitespacesAndNewlines)
+    if value.isEmpty { return false }
+    if value.contains(":") { return false } // IPv6 literal (brackets were stripped on import)
+    let octets = value.split(separator: ".")
+    if octets.count == 4, octets.allSatisfy({ Int($0).map { (0...255).contains($0) } ?? false }) {
+        return false // IPv4 literal
+    }
+    return true
+}
+
+fileprivate func plainResolverAddress(_ value: String) -> String {
+    let lower = value.lowercased()
+    for prefix in ["udp://", "http://"] where lower.hasPrefix(prefix) {
+        return String(value.dropFirst(prefix.count))
+    }
+    return value
 }
 
 private struct RegionDefinition {
@@ -1596,7 +2225,9 @@ extension ConfigurationGenerator {
     func singBox(
         nodes: [ProxyNode],
         preset: RulePreset,
-        regionGroups: [RegionStrategyGroup]
+        regionGroups: [RegionStrategyGroup],
+        dns: SubscriptionDNSConfiguration?,
+        warnings: inout [String]
     ) -> String {
         let nodeTags = nodes.map { NodeRegionResolver.displayName(for: $0) }
         let regionGroupNames = regionGroups.map(\.name)
@@ -1650,6 +2281,12 @@ extension ConfigurationGenerator {
             groups.append(.init(tag: group.automaticName, isAutomatic: true, members: group.nodeNames))
         }
 
+        let dnsPlan = singBoxDNS(
+            dns,
+            directTag: Self.singBoxDirectTag,
+            selectTag: RulePolicy.select.configurationName,
+            warnings: &warnings
+        )
         var outbounds: [[String: Any]] = groups.map { group in
             var outbound: [String: Any] = [
                 "tag": group.tag,
@@ -1665,19 +2302,19 @@ extension ConfigurationGenerator {
             }
             return outbound
         }
-        outbounds += nodes.compactMap(singBoxOutbound)
+        // A node whose server is a hostname can pin the resolver that answers
+        // it, which is what a proxy-server-nameserver-policy asks for.
+        for node in nodes {
+            guard var outbound = singBoxOutbound(node) else { continue }
+            if let resolver = dnsPlan.domainResolverTag(for: node) {
+                outbound["domain_resolver"] = ["server": resolver]
+            }
+            outbounds.append(outbound)
+        }
         outbounds.append(["tag": Self.singBoxDirectTag, "type": "direct"])
 
-        let configuration: [String: Any] = [
+        var configuration: [String: Any] = [
             "log": ["level": "warn", "timestamp": true],
-            "dns": [
-                "servers": [
-                    ["tag": "remote", "address": "https://1.1.1.1/dns-query", "detour": RulePolicy.select.configurationName],
-                    ["tag": "local", "address": "https://223.5.5.5/dns-query", "detour": Self.singBoxDirectTag]
-                ],
-                "final": "local",
-                "strategy": "prefer_ipv4"
-            ],
             "inbounds": [[
                 "type": "tun",
                 "tag": "tun-in",
@@ -1696,6 +2333,9 @@ extension ConfigurationGenerator {
                 "cache_file": ["enabled": true, "store_fakeip": false]
             ]
         ]
+        if let dnsDict = dnsPlan.dns {
+            configuration["dns"] = dnsDict
+        }
 
         guard let data = try? JSONSerialization.data(
             withJSONObject: configuration,
@@ -1918,8 +2558,16 @@ extension ConfigurationGenerator {
         _ scheme: RuleScheme,
         groups: [ResolvedSchemeGroup],
         nodes: [ProxyNode],
-        schemes: RuleSchemeRepository
+        schemes: RuleSchemeRepository,
+        dns: SubscriptionDNSConfiguration?,
+        warnings: inout [String]
     ) -> String {
+        let dnsPlan = singBoxDNS(
+            dns,
+            directTag: Self.singBoxDirectTag,
+            selectTag: groups.first?.name ?? Self.singBoxDirectTag,
+            warnings: &warnings
+        )
         var outbounds: [[String: Any]] = groups.map { group in
             var outbound: [String: Any] = [
                 "tag": group.name,
@@ -1933,7 +2581,13 @@ extension ConfigurationGenerator {
             }
             return outbound
         }
-        outbounds += nodes.compactMap(singBoxOutbound)
+        for node in nodes {
+            guard var outbound = singBoxOutbound(node) else { continue }
+            if let resolver = dnsPlan.domainResolverTag(for: node) {
+                outbound["domain_resolver"] = ["server": resolver]
+            }
+            outbounds.append(outbound)
+        }
         outbounds.append(["tag": Self.singBoxDirectTag, "type": "direct"])
 
         var rules: [[String: Any]] = []
@@ -1973,7 +2627,7 @@ extension ConfigurationGenerator {
             rules.append(rule)
         }
 
-        let configuration: [String: Any] = [
+        var configuration: [String: Any] = [
             "log": ["level": "warn", "timestamp": true],
             "inbounds": [[
                 "type": "tun",
@@ -1987,6 +2641,9 @@ extension ConfigurationGenerator {
             "route": ["rules": rules, "final": finalGroup, "auto_detect_interface": true],
             "experimental": ["cache_file": ["enabled": true, "store_fakeip": false]]
         ]
+        if let dnsDict = dnsPlan.dns {
+            configuration["dns"] = dnsDict
+        }
 
         guard let data = try? JSONSerialization.data(
             withJSONObject: configuration,
@@ -2021,12 +2678,15 @@ extension ConfigurationGenerator {
     func egern(
         nodes: [ProxyNode],
         preset: RulePreset,
-        regionGroups: [RegionStrategyGroup]
+        regionGroups: [RegionStrategyGroup],
+        dns: SubscriptionDNSConfiguration?,
+        warnings: inout [String]
     ) -> String {
         let nodeNames = nodes.map { NodeRegionResolver.displayName(for: $0) }
         let regionGroupNames = regionGroups.map(\.name)
 
         var output = header(target: .egern)
+        output += egernDNS(dns, warnings: &warnings)
         output += "\nproxies:\n"
         output += nodes.isEmpty ? "  []\n" : nodes.compactMap(egernProxy).joined()
 
@@ -2088,9 +2748,12 @@ extension ConfigurationGenerator {
         _ scheme: RuleScheme,
         groups: [ResolvedSchemeGroup],
         nodes: [ProxyNode],
-        schemes: RuleSchemeRepository
+        schemes: RuleSchemeRepository,
+        dns: SubscriptionDNSConfiguration?,
+        warnings: inout [String]
     ) -> String {
         var output = schemeHeader(scheme, target: .egern)
+        output += egernDNS(dns, warnings: &warnings)
         output += "\nproxies:\n"
         output += nodes.isEmpty ? "  []\n" : nodes.compactMap(egernProxy).joined()
 

--- a/Tower/Services/SubscriptionParser.swift
+++ b/Tower/Services/SubscriptionParser.swift
@@ -33,24 +33,27 @@ struct SubscriptionService {
 
         var result = try await load(url, source: source)
 
-        // The node list is authoritative for nodes; only the quota may be
-        // missing from it. Airports that answer `flag=clash` send a
-        // `subscription-userinfo` header, so a second request fills the gap —
-        // but its body is not used, because the panel's Clash converter drops
-        // whatever it cannot express. One real airport returns 43 of its 55
-        // nodes that way, silently losing every AnyTLS entry.
-        if result.usage?.hasPlanDetail != true, let probe = Self.quotaProbe(for: url) {
-            if let usage = try? await quota(at: probe) {
+        // The first response remains authoritative for nodes. A `flag=clash`
+        // probe can fill missing quota and DNS metadata, but its converted node
+        // list is never adopted: one real airport drops every AnyTLS entry and
+        // returns only 43 of its 55 nodes in that dialect.
+        if result.usage?.hasPlanDetail != true || result.dnsConfiguration == nil,
+           let probe = Self.quotaProbe(for: url),
+           let metadata = try? await clashMetadata(at: probe) {
+            if result.usage?.hasPlanDetail != true, let usage = metadata.usage {
                 var merged = usage
                 merged.notices = result.usage?.notices ?? []
                 result.usage = merged
+            }
+            if result.dnsConfiguration == nil {
+                result.dnsConfiguration = metadata.dnsConfiguration
             }
         }
         return result
     }
 
-    /// The same subscription asked for in Clash's dialect, purely to read the
-    /// quota header. `nil` when the caller already pinned a flag themselves.
+    /// The same subscription asked for in Clash's dialect to read its quota
+    /// header and DNS policy. `nil` when the caller pinned a flag themselves.
     private static func quotaProbe(for url: URL) -> URL? {
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return nil
@@ -61,19 +64,26 @@ struct SubscriptionService {
         return components.url
     }
 
-    private func quota(at url: URL) async throws -> SubscriptionUsage {
+    private func clashMetadata(at url: URL) async throws -> ClashMetadata {
         var request = URLRequest(url: url)
         request.timeoutInterval = 15
         request.setValue(Self.userAgent, forHTTPHeaderField: "User-Agent")
 
-        let (_, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await URLSession.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
-              (200..<300).contains(httpResponse.statusCode),
-              let header = httpResponse.value(forHTTPHeaderField: "subscription-userinfo"),
-              let usage = SubscriptionUsage.parse(header: header) else {
+              (200..<300).contains(httpResponse.statusCode) else {
             throw SubscriptionError.badResponse
         }
-        return usage
+        let usage = httpResponse.value(forHTTPHeaderField: "subscription-userinfo")
+            .flatMap(SubscriptionUsage.parse(header:))
+        let dns = parser.parseDNSConfiguration(data: data)
+        guard usage != nil || dns != nil else { throw SubscriptionError.badResponse }
+        return ClashMetadata(usage: usage, dnsConfiguration: dns)
+    }
+
+    private struct ClashMetadata {
+        let usage: SubscriptionUsage?
+        let dnsConfiguration: SubscriptionDNSConfiguration?
     }
 
     private static let userAgent = "Tower/1.0 (iOS; local subscription converter)"
@@ -105,7 +115,8 @@ struct SubscriptionService {
         return ImportResult(
             nodes: parsed.nodes,
             rejectedLineCount: parsed.rejectedLineCount,
-            usage: usage.isEmpty ? nil : usage
+            usage: usage.isEmpty ? nil : usage,
+            dnsConfiguration: parsed.dnsConfiguration
         )
     }
 }
@@ -120,6 +131,8 @@ struct SubscriptionParser {
         /// Quota read from a `STATUS=` line at the head of the list, for the
         /// panels that put it there instead of in the response header.
         var status: SubscriptionUsage?
+        /// DNS metadata from a `dns:` block, when the subscription carries one.
+        var dnsConfiguration: SubscriptionDNSConfiguration?
     }
 
     /// Names that are an announcement rather than a node.
@@ -174,7 +187,8 @@ struct SubscriptionParser {
                 nodes: deduplicated(parsed.nodes.filter { !Self.isNotice($0) }),
                 rejectedLineCount: parsed.rejectedLineCount,
                 notices: notices,
-                status: notices.lazy.compactMap(SubscriptionUsage.parse(statusLine:)).first
+                status: notices.lazy.compactMap(SubscriptionUsage.parse(statusLine:)).first,
+                dnsConfiguration: parsed.dnsConfiguration
             )
         }
 
@@ -213,6 +227,15 @@ struct SubscriptionParser {
             // Other panels write the same line in as a node remark.
             status: status ?? notices.lazy.compactMap(SubscriptionUsage.parse(statusLine:)).first
         )
+    }
+
+    /// Lightweight metadata-only path for the Clash probe. In particular this
+    /// does not make its converted proxy list authoritative. Returns `nil` when
+    /// the probe carries no `dns:` block.
+    func parseDNSConfiguration(data: Data) -> SubscriptionDNSConfiguration? {
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        let config = parseDNSConfiguration(in: text.components(separatedBy: .newlines))
+        return config.isEmpty ? nil : config
     }
 
     func parseURI(_ rawValue: String, sourceID: UUID? = nil) -> ProxyNode? {
@@ -620,8 +643,170 @@ struct SubscriptionParser {
         }
         return .init(
             nodes: nodes,
-            rejectedLineCount: dictionaries.isEmpty ? 1 : rejected
+            rejectedLineCount: dictionaries.isEmpty ? 1 : rejected,
+            dnsConfiguration: parseDNSConfiguration(in: lines)
         )
+    }
+
+    /// Reads the `dns:` block emitted by Clash/Mihomo subscription converters:
+    ///
+    ///     dns:
+    ///       enable: true
+    ///       nameserver:
+    ///         - https://dns.alidns.com/dns-query
+    ///       nameserver-policy:
+    ///         "geosite:cn":
+    ///           - https://dns.alidns.com/dns-query
+    ///
+    /// Only the fields Tower re-emits are collected; `fake-ip`, `fallback-filter`
+    /// and friends are out of scope. Matchers contain colons surprisingly often,
+    /// so the key/value separator is found outside quotes rather than with
+    /// `firstIndex(of: ":")`.
+    private func parseDNSConfiguration(in lines: [String]) -> SubscriptionDNSConfiguration {
+        guard let start = lines.firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines) == "dns:"
+        }) else { return .init() }
+        let baseIndent = indentation(of: lines[start])
+
+        var config = SubscriptionDNSConfiguration()
+        var key: String?
+        var keyIndent = 0
+        var list: [String] = []
+        var policy: [NameserverPolicyEntry] = []
+        var matcher: String?
+        var matcherValues: [String] = []
+        var matcherIndent = 0
+
+        func finishMatcher() {
+            guard let currentMatcher = matcher, !currentMatcher.isEmpty, !matcherValues.isEmpty else { return }
+            policy.append(.init(matcher: currentMatcher, nameservers: matcherValues))
+            matcher = nil
+            matcherValues = []
+            matcherIndent = 0
+        }
+
+        func commit() {
+            guard let currentKey = key else { return }
+            finishMatcher()
+            switch currentKey {
+            case "enable": config.enable = list.first?.lowercased() == "true"
+            case "default-nameserver": config.defaultNameservers = list
+            case "nameserver": config.nameservers = list
+            case "fallback": config.fallbacks = list
+            case "nameserver-policy": config.nameserverPolicy = policy
+            case "proxy-server-nameserver": config.proxyServerNameservers = list
+            case "proxy-server-nameserver-policy": config.proxyServerNameserverPolicy = policy
+            default: break
+            }
+            key = nil
+            list = []
+            policy = []
+        }
+
+        for rawLine in lines.dropFirst(start + 1) {
+            let trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+            let indent = indentation(of: rawLine)
+            if indent <= baseIndent { break }
+
+            if !trimmed.hasPrefix("-"), let pair = splitYAMLPair(trimmed) {
+                if indent <= keyIndent, key != nil { commit() }
+                // An inline `# comment` must not become part of a key or value;
+                // a fragment attached to a URL (`dns-query#probe`) has no space
+                // before the hash and survives.
+                let keyText = strippingInlineComment(pair.0)
+                let valueText = strippingInlineComment(pair.1)
+                if indent <= baseIndent + 2 {
+                    // A field of the dns block itself.
+                    key = unquoted(keyText).lowercased()
+                    keyIndent = indent
+                    list = yamlStringList(valueText)
+                } else {
+                    // A matcher inside nameserver-policy (or its proxy twin).
+                    finishMatcher()
+                    matcher = unquoted(keyText)
+                    matcherValues = yamlStringList(valueText)
+                    matcherIndent = indent
+                }
+            } else if indent > keyIndent, trimmed.hasPrefix("-") {
+                let raw = String(trimmed.dropFirst()).trimmingCharacters(in: .whitespaces)
+                let value = unquoted(strippingInlineComment(raw))
+                if value.isEmpty { continue }
+                if matcher != nil, indent > matcherIndent {
+                    matcherValues.append(value)
+                } else {
+                    list.append(value)
+                }
+            }
+        }
+        commit()
+        return config
+    }
+
+    private func indentation(of line: String) -> Int {
+        line.prefix { $0 == " " || $0 == "\t" }.count
+    }
+
+    /// YAML allows a `# comment` after a value on the same line. It must not
+    /// leak into a key or resolver; a URL fragment (`#probe`) has no space
+    /// before the hash and is kept.
+    private func strippingInlineComment(_ value: String) -> String {
+        guard let range = value.range(of: " #") else { return value }
+        return String(value[..<range.lowerBound])
+    }
+
+    private func yamlStringList(_ raw: String) -> [String] {
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard value.hasPrefix("["), value.hasSuffix("]") else {
+            let scalar = unquoted(value)
+            return scalar.isEmpty ? [] : [scalar]
+        }
+        return splitYAMLValues(String(value.dropFirst().dropLast())).map(unquoted).filter { !$0.isEmpty }
+    }
+
+    private func splitYAMLValues(_ value: String) -> [String] {
+        var result: [String] = []
+        var current = ""
+        var quote: Character?
+        for character in value {
+            if character == "\"" || character == "'" {
+                if quote == character { quote = nil }
+                else if quote == nil { quote = character }
+            }
+            if character == ",", quote == nil {
+                result.append(current.trimmingCharacters(in: .whitespaces))
+                current = ""
+            } else {
+                current.append(character)
+            }
+        }
+        if !current.isEmpty { result.append(current.trimmingCharacters(in: .whitespaces)) }
+        return result
+    }
+
+    private func unquoted(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 2,
+              let first = trimmed.first,
+              first == trimmed.last,
+              first == "\"" || first == "'" else { return trimmed }
+        return String(trimmed.dropFirst().dropLast())
+    }
+
+    private func splitYAMLPair(_ value: String) -> (String, String)? {
+        var quote: Character?
+        for index in value.indices {
+            let character = value[index]
+            if character == "\"" || character == "'" {
+                if quote == character { quote = nil }
+                else if quote == nil { quote = character }
+            } else if character == ":", quote == nil {
+                let key = String(value[..<index]).trimmingCharacters(in: .whitespacesAndNewlines)
+                let next = value.index(after: index)
+                return key.isEmpty ? nil : (key, String(value[next...]).trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+        }
+        return nil
     }
 
     private func parseInlineYAMLMap(_ value: String) -> [String: String] {
@@ -650,11 +835,8 @@ struct SubscriptionParser {
     }
 
     private func parseYAMLPair(_ value: String) -> (String, String)? {
-        guard let separator = value.firstIndex(of: ":") else { return nil }
-        let key = value[..<separator].trimmingCharacters(in: .whitespacesAndNewlines)
-        let raw = value[value.index(after: separator)...].trimmingCharacters(in: .whitespacesAndNewlines)
-        let cleaned = raw.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-        return key.isEmpty ? nil : (key.lowercased(), cleaned)
+        guard let pair = splitYAMLPair(value) else { return nil }
+        return (unquoted(pair.0).lowercased(), unquoted(pair.1))
     }
 
     private func clashKind(_ value: String) -> ProxyKind? {

--- a/TowerTests/ConfigurationGeneratorTests.swift
+++ b/TowerTests/ConfigurationGeneratorTests.swift
@@ -83,6 +83,48 @@ final class ConfigurationGeneratorTests: XCTestCase {
         XCTAssertTrue(result.content.contains("MATCH,国际流量"))
     }
 
+    func testClashCarriesNameserverPolicyWhileOtherFormatsDoNot() {
+        let dns = SubscriptionDNSConfiguration(nameserverPolicy: [
+            NameserverPolicyEntry(
+                matcher: "geosite:cn,private",
+                nameservers: ["https://dns.alidns.com/dns-query", "https://doh.pub/dns-query"]
+            )
+        ])
+        let clash = ConfigurationGenerator().generate(
+            nodes: nodes,
+            preset: RulePreset.builtIns[0],
+            target: .clash,
+            dnsConfiguration: dns
+        ).content
+        let surge = ConfigurationGenerator().generate(
+            nodes: nodes,
+            preset: RulePreset.builtIns[0],
+            target: .surge,
+            dnsConfiguration: dns
+        ).content
+
+        XCTAssertTrue(clash.contains("dns:\n  enable: true"))
+        XCTAssertTrue(clash.contains("  nameserver-policy:\n    \"geosite:cn,private\":"))
+        XCTAssertTrue(clash.contains("      - \"https://dns.alidns.com/dns-query\""))
+        XCTAssertFalse(surge.contains("nameserver-policy"))
+    }
+
+    func testClashNameserverPolicyKeepsFirstValueForDuplicateMatcher() {
+        let dns = SubscriptionDNSConfiguration(nameserverPolicy: [
+            NameserverPolicyEntry(matcher: "+.example.com", nameservers: ["tls://1.1.1.1"]),
+            NameserverPolicyEntry(matcher: "+.example.com", nameservers: ["tls://8.8.8.8"])
+        ])
+        let content = ConfigurationGenerator().generate(
+            nodes: nodes,
+            preset: RulePreset.builtIns[0],
+            target: .clash,
+            dnsConfiguration: dns
+        ).content
+
+        XCTAssertTrue(content.contains("tls://1.1.1.1"))
+        XCTAssertFalse(content.contains("tls://8.8.8.8"))
+    }
+
     func testEveryClientAddsNativeImageFieldsToStrategyGroups() {
         let generator = ConfigurationGenerator()
         let preset = RulePreset.builtIns[0]

--- a/TowerTests/DNSConversionTests.swift
+++ b/TowerTests/DNSConversionTests.swift
@@ -1,0 +1,382 @@
+import XCTest
+@testable import Tower
+
+/// End-to-end DNS conversion tests: one subscription DNS block, seven targets,
+/// both the built-in preset and the imported-scheme generation paths.
+final class DNSConversionTests: XCTestCase {
+    private let nodes = [
+        ProxyNode(
+            kind: .shadowsocks,
+            name: "Hong Kong",
+            server: "hk.example.com",
+            port: 8388,
+            cipher: "chacha20-ietf-poly1305",
+            password: "secret",
+            rawURI: "ss://test"
+        ),
+        ProxyNode(
+            kind: .vmess,
+            name: "Tokyo",
+            server: "jp.example.com",
+            port: 443,
+            uuid: "5d1c3d8f-77b7-45c7-98c7-6fa54d37766e",
+            transport: "ws",
+            tls: true,
+            sni: "jp.example.com",
+            hostHeader: "jp.example.com",
+            path: "/gateway",
+            rawURI: "vmess://test"
+        )
+    ]
+
+    private var preset: RulePreset { RulePreset.builtIns[0] }
+
+    private func generate(
+        _ target: ClientTarget,
+        dns: SubscriptionDNSConfiguration?
+    ) -> GeneratedConfiguration {
+        ConfigurationGenerator().generate(
+            nodes: nodes,
+            preset: preset,
+            target: target,
+            dnsConfiguration: dns
+        )
+    }
+
+    private func dns(
+        enable: Bool? = nil,
+        defaultNameservers: [String] = [],
+        nameservers: [String] = ["https://dns.alidns.com/dns-query"],
+        fallbacks: [String] = [],
+        policy: [NameserverPolicyEntry] = [],
+        proxyNameservers: [String] = [],
+        proxyPolicy: [NameserverPolicyEntry] = []
+    ) -> SubscriptionDNSConfiguration {
+        SubscriptionDNSConfiguration(
+            enable: enable,
+            defaultNameservers: defaultNameservers,
+            nameservers: nameservers,
+            fallbacks: fallbacks,
+            nameserverPolicy: policy,
+            proxyServerNameservers: proxyNameservers,
+            proxyServerNameserverPolicy: proxyPolicy
+        )
+    }
+
+    // MARK: - Stash / Clash (native)
+
+    func testStashWritesNativeDNSFields() {
+        let config = dns(
+            enable: false,
+            defaultNameservers: ["223.5.5.5"],
+            nameservers: ["https://dns.alidns.com/dns-query"],
+            fallbacks: ["https://dns.google/dns-query"],
+            policy: [.init(matcher: "+.example.com", nameservers: ["tls://1.1.1.1"])]
+        )
+        let content = generate(.clash, dns: config).content
+
+        XCTAssertTrue(content.contains("dns:\n  enable: false"))
+        XCTAssertTrue(content.contains("  default-nameserver:\n    - \"223.5.5.5\""))
+        XCTAssertTrue(content.contains("  nameserver:\n    - \"https://dns.alidns.com/dns-query\""))
+        XCTAssertTrue(content.contains("  fallback:\n    - \"https://dns.google/dns-query\""))
+        XCTAssertTrue(content.contains("  nameserver-policy:\n    \"+.example.com\":\n      - \"tls://1.1.1.1\""))
+    }
+
+    func testStashSkipsMihomoProxyFieldsWithWarning() {
+        let config = dns(
+            proxyNameservers: ["tls://1.1.1.1"],
+            proxyPolicy: [.init(matcher: "+.example.com", nameservers: ["https://dns.alidns.com/dns-query"])]
+        )
+        let result = generate(.clash, dns: config)
+
+        XCTAssertFalse(result.content.contains("proxy-server-nameserver"))
+        XCTAssertTrue(result.conversionWarnings.contains { $0.contains("proxy-server-nameserver") })
+        XCTAssertTrue(result.conversionWarnings.contains { $0.contains("proxy-server-nameserver-policy") })
+    }
+
+    // MARK: - Surge
+
+    func testSurgeSplitsDNSByProtocolAndMapsPolicyToHost() {
+        let config = dns(
+            nameservers: ["223.5.5.5", "https://1.1.1.1/dns-query"],
+            policy: [
+                .init(matcher: "+.example.com", nameservers: ["8.8.8.8", "9.9.9.9"]),
+                .init(matcher: "geosite:cn", nameservers: ["https://dns.alidns.com/dns-query"])
+            ]
+        )
+        let result = generate(.surge, dns: config)
+
+        XCTAssertTrue(result.content.contains("dns-server = system, 223.5.5.5"))
+        XCTAssertTrue(result.content.contains("encrypted-dns-server = https://1.1.1.1/dns-query"))
+        XCTAssertTrue(result.content.contains("[Host]\n*.example.com = server:8.8.8.8,9.9.9.9"))
+        XCTAssertTrue(result.conversionWarnings.contains { $0.contains("geosite") })
+    }
+
+    func testSurgeDropsDoTWithWarning() {
+        let config = dns(
+            nameservers: ["tls://1.1.1.1"],
+            policy: [.init(matcher: "example.com", nameservers: ["tls://8.8.8.8"])]
+        )
+        let result = generate(.surge, dns: config)
+
+        XCTAssertTrue(result.content.contains("dns-server = system"))
+        XCTAssertFalse(result.content.contains("tls://1.1.1.1"))
+        XCTAssertTrue(result.conversionWarnings.contains { $0.contains("DoT") })
+    }
+
+    // MARK: - Shadowrocket
+
+    func testShadowrocketUsesDedicatedFallbackAndProxyKeys() {
+        let config = dns(
+            nameservers: ["223.5.5.5"],
+            fallbacks: ["8.8.4.4"],
+            policy: [.init(matcher: "*.example.com", nameservers: ["8.8.8.8"])],
+            proxyNameservers: ["9.9.9.9"],
+            proxyPolicy: [.init(matcher: "+.example.net", nameservers: ["1.1.1.1"])]
+        )
+        let result = generate(.shadowrocket, dns: config)
+
+        XCTAssertTrue(result.content.contains("dns-server = system, 223.5.5.5"))
+        XCTAssertTrue(result.content.contains("fallback-dns-server = 8.8.4.4"))
+        XCTAssertTrue(result.content.contains("proxy-dns-server = 9.9.9.9"))
+        XCTAssertTrue(result.content.contains("[Host]\n*.example.com = server:8.8.8.8"))
+        // Per-domain proxy policy has no home in Shadowrocket.
+        XCTAssertTrue(result.conversionWarnings.contains { $0.contains("按域区分代理节点 DNS") })
+    }
+
+    // MARK: - Loon
+
+    func testLoonSplitsDNSByProtocolAndMapsPolicyToHost() {
+        let config = dns(
+            nameservers: ["223.5.5.5", "https://dns.alidns.com/dns-query", "quic://dns.adguard.com"],
+            fallbacks: ["h3://223.6.6.6/dns-query"],
+            policy: [.init(matcher: "*.example.com", nameservers: ["8.8.8.8"])]
+        )
+        let result = generate(.loon, dns: config)
+
+        XCTAssertTrue(result.content.contains("dns-server = system, 223.5.5.5"))
+        XCTAssertTrue(result.content.contains("doh-server = https://dns.alidns.com/dns-query"))
+        XCTAssertTrue(result.content.contains("doq-server = quic://dns.adguard.com"))
+        XCTAssertTrue(result.content.contains("doh3-server = h3://223.6.6.6/dns-query"))
+        XCTAssertTrue(result.content.contains("[Host]\n*.example.com = server:8.8.8.8"))
+    }
+
+    // MARK: - Quantumult X
+
+    func testQuanXDNSAndDomainBinding() {
+        let config = dns(
+            nameservers: ["223.5.5.5", "https://dns.alidns.com/dns-query"],
+            policy: [
+                .init(matcher: "example.com", nameservers: ["8.8.8.8"]),
+                .init(matcher: "+.example.org", nameservers: ["https://dns.google/dns-query"])
+            ]
+        )
+        let result = generate(.quanx, dns: config)
+
+        XCTAssertTrue(result.content.contains("[dns]\nno-system"))
+        XCTAssertTrue(result.content.contains("server = 223.5.5.5"))
+        XCTAssertTrue(result.content.contains("doh-server = https://dns.alidns.com/dns-query"))
+        XCTAssertTrue(result.content.contains("server = /example.com/8.8.8.8"))
+        XCTAssertTrue(result.content.contains("doh-server = /*.example.org/https://dns.google/dns-query"))
+    }
+
+    // MARK: - Egern
+
+    func testEgernBuildsBootstrapUpstreamsAndForward() {
+        let config = dns(
+            defaultNameservers: ["223.5.5.5"],
+            nameservers: ["https://dns.alidns.com/dns-query"],
+            policy: [
+                .init(matcher: "+.example.com", nameservers: ["8.8.8.8"]),
+                .init(matcher: "*.example.net", nameservers: ["tls://1.1.1.1", "https://8.8.8.8/dns-query"])
+            ],
+            proxyNameservers: ["9.9.9.9"]
+        )
+        let result = generate(.egern, dns: config)
+
+        XCTAssertTrue(result.content.contains("dns:"))
+        XCTAssertTrue(result.content.contains("  bootstrap:\n    - \"223.5.5.5\""))
+        XCTAssertTrue(result.content.contains("  upstreams:\n    main:\n      - \"https://dns.alidns.com/dns-query\""))
+        // A single-resolver policy is forwarded inline.
+        XCTAssertTrue(result.content.contains("    - domain_wildcard:\n        match: \"*.example.com\"\n        value: \"8.8.8.8\""))
+        // A multi-resolver policy keeps its group intact.
+        XCTAssertTrue(result.content.contains("    policy-example-net:\n      - \"tls://1.1.1.1\"\n      - \"https://8.8.8.8/dns-query\""))
+        XCTAssertTrue(result.content.contains("  proxy_nameservers:\n    - \"9.9.9.9\""))
+        // Without a catch-all, Egern would answer everything with bootstrap and
+        // never touch the airport's upstreams, so a catch-all follows the
+        // policy rules.
+        XCTAssertTrue(result.content.contains("    - domain_regex:\n        match: \".*\"\n        value: \"main\""))
+    }
+
+    // MARK: - Hiddify (sing-box)
+
+    func testHiddifyBuildsDNSServersRulesAndDomainResolver() throws {
+        let config = dns(
+            nameservers: ["https://dns.alidns.com/dns-query", "https://1.1.1.1/dns-query"],
+            policy: [.init(matcher: "+.example.com", nameservers: ["tls://1.1.1.1"])],
+            proxyNameservers: ["9.9.9.9"]
+        )
+        let result = generate(.hiddify, dns: config)
+        XCTAssertTrue(result.conversionWarnings.isEmpty)
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(result.content.utf8)) as? [String: Any]
+        )
+        let dnsBlock = try XCTUnwrap(object["dns"] as? [String: Any])
+        let servers = try XCTUnwrap(dnsBlock["servers"] as? [[String: Any]])
+        XCTAssertTrue(servers.contains { ($0["address"] as? String) == "https://dns.alidns.com/dns-query" })
+        XCTAssertTrue(servers.contains { ($0["address"] as? String) == "9.9.9.9" })
+
+        let rules = try XCTUnwrap(dnsBlock["rules"] as? [[String: Any]])
+        XCTAssertTrue(rules.contains { ($0["domain_suffix"] as? [String]) == [".example.com"] })
+
+        // Node hostnames resolve through the proxy nameserver, which gets the
+        // next tag after the two local resolvers and the policy rule's server.
+        let outbounds = try XCTUnwrap(object["outbounds"] as? [[String: Any]])
+        let node = try XCTUnwrap(outbounds.first { ($0["server"] as? String) == "hk.example.com" })
+        XCTAssertEqual((node["domain_resolver"] as? [String: Any])?["server"] as? String, "ns-3")
+    }
+
+    func testHiddifyDistinguishesApexSuffixFromWildcard() throws {
+        let config = dns(policy: [
+            .init(matcher: "+.example.com", nameservers: ["https://dns.alidns.com/dns-query"]),
+            .init(matcher: "*.example.net", nameservers: ["https://1.1.1.1/dns-query"])
+        ])
+        let result = generate(.hiddify, dns: config)
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(result.content.utf8)) as? [String: Any]
+        )
+        let rules = try XCTUnwrap((object["dns"] as? [String: Any])?["rules"] as? [[String: Any]])
+        XCTAssertTrue(rules.contains { ($0["domain_suffix"] as? [String]) == [".example.com"] })
+        XCTAssertTrue(rules.contains { ($0["domain_wildcard"] as? [String]) == ["*.example.net"] })
+    }
+
+    func testEmptyDNSBlockFallsBackToBuiltInDefaults() {
+        for target in ClientTarget.allCases {
+            let empty = generate(target, dns: SubscriptionDNSConfiguration())
+            let absent = generate(target, dns: nil)
+            XCTAssertEqual(empty.content, absent.content, target.name)
+            XCTAssertTrue(empty.conversionWarnings.isEmpty, target.name)
+        }
+    }
+
+    // MARK: - Shared rules
+
+    func testGeositeOnlySurvivesInStash() {
+        let config = dns(policy: [
+            .init(matcher: "geosite:cn", nameservers: ["https://dns.alidns.com/dns-query"])
+        ])
+
+        for target in ClientTarget.allCases {
+            let result = generate(target, dns: config)
+            if target == .clash {
+                XCTAssertTrue(result.content.contains("geosite:cn"), target.name)
+                XCTAssertTrue(result.conversionWarnings.isEmpty, target.name)
+            } else {
+                XCTAssertFalse(result.content.contains("geosite:cn"), target.name)
+                XCTAssertTrue(result.conversionWarnings.contains { $0.contains("geosite") }, target.name)
+            }
+        }
+    }
+
+    func testUnsupportedProtocolIsNeverDowngradedInStash() {
+        // Everything Mihomo speaks stays verbatim in the Stash target.
+        let config = dns(nameservers: [
+            "223.5.5.5", "tls://1.1.1.1", "https://dns.google/dns-query", "quic://dns.adguard.com", "h3://dns.google/dns-query"
+        ])
+        let content = generate(.clash, dns: config).content
+        for resolver in config.nameservers {
+            XCTAssertTrue(content.contains(resolver), resolver)
+        }
+    }
+
+    func testConversionWarningsAreDeduplicated() {
+        let config = dns(policy: [
+            .init(matcher: "geosite:cn", nameservers: ["https://dns.alidns.com/dns-query"]),
+            .init(matcher: "geosite:cn", nameservers: ["https://8.8.8.8/dns-query"])
+        ])
+        let result = generate(.surge, dns: config)
+
+        XCTAssertEqual(result.conversionWarnings.filter { $0.contains("geosite") }.count, 1)
+    }
+
+    func testDefaultsAreUsedWhenAirportShipsNoDNS() {
+        for target in ClientTarget.allCases {
+            let result = generate(target, dns: nil)
+            XCTAssertTrue(result.conversionWarnings.isEmpty, target.name)
+        }
+        XCTAssertTrue(generate(.clash, dns: nil).content.contains("https://223.5.5.5/dns-query"))
+        XCTAssertTrue(generate(.surge, dns: nil).content.contains("dns-server = system, 223.5.5.5, 1.1.1.1"))
+        XCTAssertTrue(generate(.quanx, dns: nil).content.contains("[dns]\nno-system\nserver = 223.5.5.5"))
+    }
+
+    // MARK: - Imported scheme path
+
+    func testSchemeGenerationCarriesDNSForEveryClient() {
+        let scheme = RuleScheme(
+            id: "dns-test",
+            name: "DNS Test",
+            summary: "DNS Test",
+            groups: [
+                RuleSchemeGroup(name: "🚀 节点选择", kind: .select, members: [.nodePattern(".*")])
+            ],
+            rulesets: [
+                RuleSchemeRuleset(groupName: "🚀 节点选择", resource: .inline("[]FINAL"))
+            ]
+        )
+        let config = dns(
+            nameservers: ["223.5.5.5"],
+            policy: [.init(matcher: "+.example.com", nameservers: ["8.8.8.8"])]
+        )
+
+        for target in ClientTarget.allCases {
+            let result = ConfigurationGenerator().generate(
+                nodes: nodes,
+                scheme: scheme,
+                target: target,
+                dnsConfiguration: config
+            )
+            XCTAssertGreaterThan(result.content.count, 100, target.name)
+            XCTAssertFalse(result.content.isEmpty, target.name)
+        }
+
+        let clash = ConfigurationGenerator().generate(nodes: nodes, scheme: scheme, target: .clash, dnsConfiguration: config).content
+        XCTAssertTrue(clash.contains("  nameserver:\n    - \"223.5.5.5\""))
+        let surge = ConfigurationGenerator().generate(nodes: nodes, scheme: scheme, target: .surge, dnsConfiguration: config).content
+        XCTAssertTrue(surge.contains("dns-server = system, 223.5.5.5"))
+        XCTAssertTrue(surge.contains("[Host]\n*.example.com = server:8.8.8.8"))
+    }
+
+    // MARK: - Escaping / injection
+
+    func testNewlineInjectionCannotOpenASectionInINITargets() {
+        // A hostile nameserver pretends to end the line and open a new section.
+        let config = SubscriptionDNSConfiguration(
+            nameservers: ["223.5.5.5\n[Proxy]\nDIRECT = direct"],
+            nameserverPolicy: [
+                .init(matcher: "example.com", nameservers: ["1.1.1.1\n[General]\ndns-server = hijacked"])
+            ]
+        )
+
+        let surge = generate(.surge, dns: config).content
+        // confValue folds the newline into the value line, so no second
+        // [Proxy] section header appears: the header occurs exactly once.
+        XCTAssertEqual(surge.components(separatedBy: "\n[Proxy]\n").count, 2)
+        XCTAssertFalse(surge.split(separator: "\n").contains("DIRECT = direct"))
+
+        let clash = generate(.clash, dns: config).content
+        // yaml() folds the value, keeping it a single quoted scalar inside
+        // the dns block rather than a top-level key.
+        XCTAssertEqual(clash.split(separator: "\n").filter { $0 == "proxies:" }.count, 1)
+    }
+
+    func testEgernGroupNameSurvivesWeirdMatcherCharacters() {
+        let config = dns(policy: [
+            .init(matcher: "*.Example.Com", nameservers: ["tls://1.1.1.1", "https://8.8.8.8/dns-query"])
+        ])
+        let result = generate(.egern, dns: config)
+
+        XCTAssertTrue(result.content.contains("policy-Example-Com"))
+    }
+}

--- a/TowerTests/ExportPresentationTests.swift
+++ b/TowerTests/ExportPresentationTests.swift
@@ -74,6 +74,33 @@ final class ExportPresentationTests: XCTestCase {
         XCTAssertEqual(cache[currentKey]?.target, .loon)
     }
 
+    /// Disabling a subscription changes the merged DNS metadata, so the cache
+    /// key must differ and the old configuration must no longer be served.
+    func testGenerationCacheInvalidatesWhenDNSConfigurationChanges() {
+        var cache = ConfigurationCache()
+        let withDNS = GenerationCacheKey(
+            target: .clash,
+            presetID: "rules",
+            nodesHash: 1,
+            countryCodesHash: 1,
+            dnsHash: 42
+        )
+        let withoutDNS = GenerationCacheKey(
+            target: .clash,
+            presetID: "rules",
+            nodesHash: 1,
+            countryCodesHash: 1,
+            dnsHash: 0
+        )
+
+        cache[withDNS] = configuration(for: .clash)
+        cache[withoutDNS] = configuration(for: .clash)
+
+        XCTAssertEqual(cache.count, 2)
+        XCTAssertNotNil(cache[withDNS])
+        XCTAssertNotNil(cache[withoutDNS])
+    }
+
     private func configuration(for target: ClientTarget) -> GeneratedConfiguration {
         GeneratedConfiguration(
             target: target,

--- a/TowerTests/SubscriptionParserTests.swift
+++ b/TowerTests/SubscriptionParserTests.swift
@@ -101,4 +101,117 @@ final class SubscriptionParserTests: XCTestCase {
         XCTAssertEqual(result.nodes[0].hostHeader, "cdn.example.com")
         XCTAssertEqual(result.nodes[0].alterID, 0)
     }
+
+    func testParsesClashNameserverPolicyScalarsAndLists() {
+        let yaml = """
+        dns:
+          enable: true
+          nameserver-policy:
+            "geosite:cn,private":
+              - https://dns.alidns.com/dns-query
+              - "https://doh.pub/dns-query"
+            '+.example.com': 'tls://1.1.1.1'
+            "geosite:geolocation-!cn": [https://1.1.1.1/dns-query, "https://8.8.8.8/dns-query"]
+        proxies:
+          - { name: HK, type: ss, server: hk.example.com, port: 8388, cipher: aes-256-gcm, password: secret }
+        """
+
+        let result = SubscriptionParser().parse(data: Data(yaml.utf8))
+        let expected: [NameserverPolicyEntry] = [
+            .init(
+                matcher: "geosite:cn,private",
+                nameservers: ["https://dns.alidns.com/dns-query", "https://doh.pub/dns-query"]
+            ),
+            .init(matcher: "+.example.com", nameservers: ["tls://1.1.1.1"]),
+            .init(
+                matcher: "geosite:geolocation-!cn",
+                nameservers: ["https://1.1.1.1/dns-query", "https://8.8.8.8/dns-query"]
+            )
+        ]
+
+        XCTAssertEqual(result.dnsConfiguration?.nameserverPolicy, expected)
+        XCTAssertEqual(
+            SubscriptionParser().parseDNSConfiguration(data: Data(yaml.utf8)),
+            result.dnsConfiguration,
+            "Clash 元数据探测不需要采用探测响应中的节点"
+        )
+    }
+
+    func testParsesEveryFieldOfTheDNSBlock() {
+        let yaml = """
+        dns:
+          enable: false
+          default-nameserver:
+            - 223.5.5.5
+          nameserver: [https://dns.alidns.com/dns-query, "https://1.1.1.1/dns-query"]
+          fallback:
+            - 'https://dns.google/dns-query'
+          nameserver-policy:
+            "geosite:cn": https://doh.pub/dns-query
+          proxy-server-nameserver:
+            - tls://1.1.1.1
+          proxy-server-nameserver-policy:
+            '+.example.com':
+              - https://dns.alidns.com/dns-query
+        proxies:
+          - { name: HK, type: ss, server: hk.example.com, port: 8388, cipher: aes-256-gcm, password: secret }
+        """
+
+        let config = SubscriptionParser().parse(data: Data(yaml.utf8)).dnsConfiguration
+        let expected = SubscriptionDNSConfiguration(
+            enable: false,
+            defaultNameservers: ["223.5.5.5"],
+            nameservers: ["https://dns.alidns.com/dns-query", "https://1.1.1.1/dns-query"],
+            fallbacks: ["https://dns.google/dns-query"],
+            nameserverPolicy: [.init(matcher: "geosite:cn", nameservers: ["https://doh.pub/dns-query"])],
+            proxyServerNameservers: ["tls://1.1.1.1"],
+            proxyServerNameserverPolicy: [
+                .init(matcher: "+.example.com", nameservers: ["https://dns.alidns.com/dns-query"])
+            ]
+        )
+
+        XCTAssertEqual(config, expected)
+    }
+
+    func testDNSBlockInlineCommentsAreStrippedButURLFragmentsSurvive() {
+        let yaml = """
+        dns:
+          enable: true # enabled by the airport
+          nameserver:
+            - https://dns.alidns.com/dns-query#probe
+          nameserver-policy:
+            "geosite:cn": https://doh.pub/dns-query # domestic
+        proxies:
+          - { name: HK, type: ss, server: hk.example.com, port: 8388, cipher: aes-256-gcm, password: secret }
+        """
+
+        let config = SubscriptionParser().parse(data: Data(yaml.utf8)).dnsConfiguration
+        XCTAssertEqual(config?.enable, true)
+        XCTAssertEqual(config?.nameservers, ["https://dns.alidns.com/dns-query#probe"])
+        XCTAssertEqual(
+            config?.nameserverPolicy,
+            [.init(matcher: "geosite:cn", nameservers: ["https://doh.pub/dns-query"])]
+        )
+    }
+
+    func testUnknownDNSBlockFieldsAndIgnoredExtensionsAreDropped() {
+        let yaml = """
+        dns:
+          enable: true
+          enhanced-mode: fake-ip
+          fake-ip-range: 198.18.0.1/16
+          respect-rules: false
+          nameserver:
+            - 223.5.5.5
+        proxies:
+          - { name: HK, type: ss, server: hk.example.com, port: 8388, cipher: aes-256-gcm, password: secret }
+        """
+
+        let config = SubscriptionParser().parse(data: Data(yaml.utf8)).dnsConfiguration
+        XCTAssertEqual(config?.enable, true)
+        XCTAssertEqual(config?.nameservers, ["223.5.5.5"])
+        // Out-of-scope extensions do not leak into the model.
+        XCTAssertTrue(config?.fallbacks.isEmpty ?? false)
+        XCTAssertTrue(config?.proxyServerNameservers.isEmpty ?? false)
+    }
 }

--- a/TowerTests/SubscriptionUsageTests.swift
+++ b/TowerTests/SubscriptionUsageTests.swift
@@ -222,6 +222,21 @@ final class SubscriptionUsageTests: XCTestCase {
         XCTAssertEqual(restored.usage?.notices, ["剩余流量：50 GB"])
     }
 
+    func testNameserverPolicySurvivesEncoding() throws {
+        let source = SubscriptionSource(
+            name: "Airport",
+            urlString: "https://example.com/sub",
+            dnsConfiguration: SubscriptionDNSConfiguration(nameserverPolicy: [
+                .init(matcher: "geosite:cn", nameservers: ["https://dns.alidns.com/dns-query"])
+            ])
+        )
+
+        let data = try JSONEncoder().encode(source)
+        let restored = try JSONDecoder().decode(SubscriptionSource.self, from: data)
+
+        XCTAssertEqual(restored.dnsConfiguration, source.dnsConfiguration)
+    }
+
     func testSourceSavedBeforeThisFeatureStillDecodes() throws {
         let legacy = """
         {
@@ -236,5 +251,49 @@ final class SubscriptionUsageTests: XCTestCase {
         let restored = try JSONDecoder().decode(SubscriptionSource.self, from: Data(legacy.utf8))
 
         XCTAssertNil(restored.usage)
+        XCTAssertNil(restored.dnsConfiguration)
+    }
+
+    func testDNSMergeFirstNonEmptyWinsPerGlobalField() {
+        let first = SubscriptionDNSConfiguration(
+            defaultNameservers: ["223.5.5.5"],
+            nameservers: ["https://dns.alidns.com/dns-query"]
+        )
+        let second = SubscriptionDNSConfiguration(
+            defaultNameservers: ["1.1.1.1"],
+            nameservers: ["https://1.1.1.1/dns-query"],
+            fallbacks: ["https://dns.google/dns-query"]
+        )
+
+        let merged = SubscriptionDNSConfiguration.merged([first, second])
+
+        XCTAssertEqual(merged?.defaultNameservers, ["223.5.5.5"])
+        XCTAssertEqual(merged?.nameservers, ["https://dns.alidns.com/dns-query"])
+        XCTAssertEqual(merged?.fallbacks, ["https://dns.google/dns-query"])
+    }
+
+    func testDNSMergeFirstOccurrenceWinsPerMatcher() {
+        let first = SubscriptionDNSConfiguration(nameserverPolicy: [
+            .init(matcher: "geosite:cn", nameservers: ["https://dns.alidns.com/dns-query"])
+        ])
+        let second = SubscriptionDNSConfiguration(nameserverPolicy: [
+            .init(matcher: "geosite:cn", nameservers: ["https://8.8.8.8/dns-query"]),
+            .init(matcher: "+.example.com", nameservers: ["tls://1.1.1.1"])
+        ])
+
+        let merged = SubscriptionDNSConfiguration.merged([first, second])
+
+        XCTAssertEqual(merged?.nameserverPolicy, [
+            .init(matcher: "geosite:cn", nameservers: ["https://dns.alidns.com/dns-query"]),
+            .init(matcher: "+.example.com", nameservers: ["tls://1.1.1.1"])
+        ])
+    }
+
+    func testDNSMergeOfEmptyConfigsIsNil() {
+        XCTAssertNil(SubscriptionDNSConfiguration.merged([]))
+        XCTAssertNil(SubscriptionDNSConfiguration.merged([
+            SubscriptionDNSConfiguration(),
+            SubscriptionDNSConfiguration()
+        ]))
     }
 }

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -185,6 +185,17 @@ Egern 也已支持（含 `egern:/profiles/new` 一键导入，注意是**单**�
 - 地图右上角的整体测速按钮已移除；逐节点测速仍在展开后的节点详情里。
 - 订阅套餐流量：按 `subscription-userinfo` 响应头 → 内容里的 `STATUS=` 行 → 节点列表公告行取值。节点始终以订阅原地址返回体为准，`flag=clash` 只在缺结构化配额时补发一次且只读响应头——机场的 Clash 转换器会丢掉它表达不了的协议（实测少 12 个 AnyTLS 节点）。
 
+## 1.5 2026-08-09 跨客户端 DNS Policy 转换
+
+实现 `docs/dns-policy-conversion-plan.md`，订阅携带的 Clash `dns:` 块不再被丢弃，而是按各客户端原生语法做保守转换：
+
+- 解析并持久化 `SubscriptionDNSConfiguration`：`enable`、`default-nameserver`、`nameserver`、`fallback`、`nameserver-policy`、`proxy-server-nameserver`、`proxy-server-nameserver-policy`。普通订阅响应和 `flag=clash` 探测响应都提取 DNS；探测响应仍只读元数据，绝不采用其转换出的节点列表。
+- 多订阅按列表顺序合并：全局字段取首个非空值（不混合不同机场的上游），相同 matcher 取先出现的一条。禁用订阅立即退出合并；生成缓存键新增 `dnsHash`，开关订阅自动使缓存失效。
+- 七目标转换（内置 preset 与导入 scheme 共用同一套渲染）：Stash 原生输出；Surge/Shadowrocket/Loon 转 `dns-server`/`doh-server` 等键及 `[Host] domain = server:…`；QuanX 转 `[dns] server`/`doh-server`/`doq-server` 与 `/pattern/resolver` 域名绑定；Egern 转 `bootstrap`/`upstreams`/`forward`/`proxy_nameservers`（含兜底 `.*` 规则，否则主 upstream 组永远不会被查询）；Hiddify 转 `dns.servers`/`dns.rules`，并用节点 outbound 的 `domain_resolver` 应用代理 DNS。
+- 只转换 exact、`+.`、`*.` matcher；`geosite:*` 只在 Stash 保留。协议或条目目标无法表达时跳过并产生结构化 `conversionWarnings`（如 Surge 不认 DoT、Stash 不输出 Mihomo 专属 proxy 字段），导出摘要展示且不阻塞预览/复制/导入。
+- 机场未提供 DNS 时各目标保持原有硬编码默认值；`+.` 与 `*.` 的 apex 语义在能区分的目标（sing-box）上忠实保留。DNS 文本按目标格式经 `yaml()`/`confName`/`confValue`/JSON 转义，防止注入新配置段。
+- 测试：`DNSConversionTests`（18 条）覆盖七目标、两种生成路径、geosite 边界、协议不支持警告、警告去重与注入防护；解析器测试覆盖全字段、行内注释、URL fragment 与范围外字段忽略。全量 310 条测试通过。
+
 ## 2. 产品目标与确定的交互
 
 ### 首页

--- a/docs/dns-policy-conversion-plan.md
+++ b/docs/dns-policy-conversion-plan.md
@@ -1,0 +1,59 @@
+# 跨客户端 DNS Policy 转换
+
+## Summary
+
+将当前仅支持 Stash `nameserver-policy` 的实现升级为统一 DNS 模型，并按目标客户端的原生语法做保守、尽力转换。
+
+Mihomo 明确区分普通域名解析、代理节点域名解析及各自 policy；它们不能互相替代。[Mihomo DNS 文档](https://wiki.metacubex.one/en/config/dns/)
+
+Stash、Surge、Egern、Quantumult X、Loon 和 sing-box 均有不同表达方式：[Stash](https://stash.wiki/en/features/dns-server)、[Surge](https://manual.nssurge.com/dns/local-dns-mapping.html)、[Egern](https://egernapp.com/docs/configuration/dns/)、[Quantumult X](https://github.com/crossutility/Quantumult-X/blob/master/sample.conf)、[Loon](https://github.com/Loon0x00/LoonExampleConfig/blob/master/example.conf)、[sing-box](https://sing-box.sagernet.org/configuration/dns/rule/)。
+
+## Key Changes
+
+- 新增可持久化的 `SubscriptionDNSConfiguration`，读取：
+  - `enable`
+  - `default-nameserver`
+  - `nameserver`
+  - `fallback`
+  - `nameserver-policy`
+  - `proxy-server-nameserver`
+  - `proxy-server-nameserver-policy`
+- 普通订阅响应与 `flag=clash` 探测响应都提取 DNS；探测响应仍不得替换原始节点列表。
+- 多订阅按列表顺序合并：
+  - 每个全局字段采用首个非空值，不混合不同机场的上游服务器。
+  - 相同 matcher 采用先出现的 policy。
+  - 禁用订阅立即退出 DNS 合并并使生成缓存失效。
+- 仅转换 exact、`+.`、`*.` 等可明确映射的 matcher；`geosite:*` 仅在 Stash 保留，其他目标跳过并警告，不展开大型域名列表、不引入外部规则下载。
+- 不降级 DNS 协议、不把多个解析器静默缩减为一个；目标格式无法表达时跳过该条并产生结构化警告。
+
+| 目标 | 普通 DNS policy | 代理节点 DNS |
+|---|---|---|
+| Stash | 原生 `default-nameserver`、`nameserver`、`nameserver-policy` | Mihomo 专属字段不输出并警告 |
+| Surge | `dns-server` / `encrypted-dns-server`；policy 转 `[Host] domain = server:...` | 无等价字段，警告 |
+| Shadowrocket | `dns-server`、`fallback-dns-server`；policy 转 `[Host]` | 全局转 `proxy-dns-server`；按域 policy 警告 |
+| Loon | `dns-server` / `doh-server`；单解析器 policy 转 `[Host]` | 无等价字段，警告 |
+| Quantumult X | 按协议转 `[dns] server`、`doh-server`、`doq-server` 及域名绑定语法 | 无等价字段，警告 |
+| Egern | 转 `bootstrap`、`upstreams`、`forward`，保留多解析器组 | 全局转 `proxy_nameservers`；按域 policy 警告 |
+| Hiddify | 按现有 sing-box 1.13 兼容格式生成 `dns.servers`、`dns.rules` | 用 outbound `domain_resolver` 对已知节点域名应用 policy |
+
+- `GeneratedConfiguration` 增加结构化 `conversionWarnings`。
+- 导出摘要显示每条 DNS 转换警告；警告不阻止预览、复制或导入。
+- 当前硬编码 DNS 仅作为字段缺失时的默认值；机场提供了可支持字段时由机场配置替代。
+- 内置规则与导入规则方案走同一套 DNS 生成路径。
+
+## Test Plan
+
+- 解析 block、scalar、inline array、引号、带冒号 matcher、URL fragment 及两类 policy。
+- 验证旧状态文件可解码，DNS 元数据刷新和禁用订阅行为正确。
+- 覆盖多订阅冲突、首订阅优先、缓存失效及警告去重。
+- 为七个目标分别验证普通 policy、代理 DNS、通配符展开、协议支持和不可转换警告。
+- 同时覆盖内置 preset 与导入 scheme 的生成路径。
+- 验证 YAML/INI/JSON 转义，防止订阅内容注入配置段。
+- 运行完整 Xcode 测试；sing-box 输出继续通过 JSON 解析，并为每种文本格式增加关键段落快照断言。
+
+## Assumptions
+
+- “Clash YAML”目标继续以 Stash 兼容性为准，不输出未被 Stash 官方确认的 Mihomo 专属字段。
+- 本期不转换 `fake-ip`、`fallback-filter`、`respect-rules`、ECS 等扩展配置。
+- 不为 `geosite` 做近似映射，也不自动下载额外规则集。
+- 无法无损表达的内容采用非阻塞警告，不静默改变语义。


### PR DESCRIPTION
## 背景

实现 `docs/dns-policy-conversion-plan.md`。机场订阅里携带的 Clash `dns:` 块此前被静默丢弃——这会让客户端在 DNS 污染严重的网络里解析不出节点。本次把它解析、合并并按七种客户端的原生语法保守转换。

## 改动

- **模型**：新增可持久化的 `SubscriptionDNSConfiguration`（`enable`/`default-nameserver`/`nameserver`/`fallback`/`nameserver-policy`/`proxy-server-nameserver`/`proxy-server-nameserver-policy`）；`GeneratedConfiguration` 增加 `conversionWarnings`。
- **解析**：普通订阅响应与 `flag=clash` 探测都提取 DNS；探测响应仍只读元数据，不采用其转换出的节点列表（机场 Clash 转换器会丢节点，实测少 12 个 AnyTLS）。
- **合并**：多订阅按列表顺序合并——全局字段首个非空值优先（不混合不同机场上游）、相同 matcher 首条优先；禁用订阅退出合并。生成缓存键新增 `dnsHash`，开关订阅自动失效缓存。
- **七目标转换**（内置 preset 与导入 scheme 共用同一套渲染）：
  | 目标 | 普通 DNS | 代理节点 DNS |
  |---|---|---|
  | Stash | 原生 `default-nameserver`/`nameserver`/`fallback`/`nameserver-policy` | Mihomo 专属字段不输出并警告 |
  | Surge | `dns-server`/`encrypted-dns-server`；policy 转 `[Host]` | 无对应字段，警告 |
  | Shadowrocket | `dns-server`/`fallback-dns-server`；policy 转 `[Host]` | 全局转 `proxy-dns-server`；按域 policy 警告 |
  | Loon | `dns-server`/`doh-server`/`doq-server`/`doh3-server`；policy 转 `[Host]` | 无对应字段，警告 |
  | Quantumult X | `server`/`doh-server`/`doq-server` + `/pattern/` 域名绑定 | 无对应字段，警告 |
  | Egern | `bootstrap`/`upstreams`/`forward`（含兜底 `.*` 规则，否则主 upstream 组永不生效） | `proxy_nameservers`；按域 policy 警告 |
  | Hiddify | `dns.servers`/`dns.rules` | 节点 outbound 的 `domain_resolver` 按 matcher 应用 |
- **边界**：只转换 exact、`+.`、`*.` matcher；`geosite:*` 只在 Stash 保留（不展开、不下载规则集）。协议目标无法表达时不降级、不静默缩减——跳过该条并产生结构化警告，导出摘要展示，不阻塞预览/复制/导入。`+.` 与 `*.` 的 apex 语义在能区分的目标（sing-box）上忠实保留。
- **转义**：DNS 文本按目标格式经 `yaml()`/`confName`/`confValue`/JSON 处理，防止订阅内容换行注入新配置段（有注入测试钉住）。
- **默认值**：机场未提供 DNS 时各目标保持原有硬编码默认，输出与改动前完全一致。

## 测试

- 全量 **310 条测试通过**（新增 `DNSConversionTests` 18 条 + 解析器/合并/缓存键测试）。
- 覆盖：七目标普通 policy、代理 DNS、通配符展开、协议不支持警告、geosite 边界、警告去重、内置 preset 与导入 scheme 双路径、YAML/INI/JSON 注入防护、旧存档解码、禁用订阅缓存失效。

## 注意

- 真机导入未验证（需各客户端实测 `[Host]`/`[dns]` 绑定语法）；转换是"保守尽力"语义，个别客户端语法以文档为准（Surge `[Host]` server:、QuanX `/pattern/` 绑定、Egern forward、sing-box `domain_resolver`）。
- 未改 bundle 版本号。